### PR TITLE
Fix Settings Persistence and Cancel Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.4] - 2026-07-18
+
+### Fixed
+
+-   Cancel now restores the last saved settings instead of built-in defaults
+-   Prevented a race where closing the popup before settings finished loading could overwrite saved options with defaults
+-   Merged stored settings with defaults so missing keys from older installs are filled in
+
 ## [1.2.3] - 2025-06-25
 
 ### Fixed

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "chatgpt-styler",
     "description": "Extension to allow users to change the styling for their ChatGPT experience.",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "action": {
         "default_icon": {
             "16": "icon-16.png",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,14 +26,14 @@ flowchart LR
 
 Source of truth in-repo: [`dist/manifest.json`](../dist/manifest.json).
 
-| Manifest field | Value / meaning |
-|----------------|-----------------|
-| `manifest_version` | `3` |
-| `action.default_popup` | `popup.html` → loads `js/popup.js` |
-| `background.service_worker` | `js/backgroundPage.js` |
-| `content_scripts` | `js/contentScript.js` on `*://chatgpt.com/*` |
-| `host_permissions` | `*://chatgpt.com/*` |
-| `permissions` | `activeTab`, `storage` |
+| Manifest field              | Value / meaning                              |
+| --------------------------- | -------------------------------------------- |
+| `manifest_version`          | `3`                                          |
+| `action.default_popup`      | `popup.html` → loads `js/popup.js`           |
+| `background.service_worker` | `js/backgroundPage.js`                       |
+| `content_scripts`           | `js/contentScript.js` on `*://chatgpt.com/*` |
+| `host_permissions`          | `*://chatgpt.com/*`                          |
+| `permissions`               | `activeTab`, `storage`                       |
 
 Webpack does **not** copy or generate the manifest. Static files under `dist/` (manifest, `popup.html`, icons) are maintained alongside built JS in `dist/js/`.
 
@@ -41,11 +41,11 @@ Webpack does **not** copy or generate the manifest. Static files under `dist/` (
 
 Defined in [`webpack.common.js`](../webpack.common.js):
 
-| Entry key | Source | Output |
-|-----------|--------|--------|
+| Entry key        | Source                                              | Output                      |
+| ---------------- | --------------------------------------------------- | --------------------------- |
 | `backgroundPage` | [`src/backgroundPage.ts`](../src/backgroundPage.ts) | `dist/js/backgroundPage.js` |
-| `popup` | [`src/popup/index.tsx`](../src/popup/index.tsx) | `dist/js/popup.js` |
-| `contentScript` | [`src/contentScript.ts`](../src/contentScript.ts) | `dist/js/contentScript.js` |
+| `popup`          | [`src/popup/index.tsx`](../src/popup/index.tsx)     | `dist/js/popup.js`          |
+| `contentScript`  | [`src/contentScript.ts`](../src/contentScript.ts)   | `dist/js/contentScript.js`  |
 
 Shared modules (`@src/...`) are bundled into each entry that imports them. Alias `@src` → `src/`.
 
@@ -55,23 +55,23 @@ Dev vs prod: [`webpack.dev.js`](../webpack.dev.js) (watch + inline source maps) 
 
 ### Popup
 
-- [`src/popup/index.tsx`](../src/popup/index.tsx) — mounts `<Popup />` into `#popup`, imports global CSS.
-- [`src/popup/component.tsx`](../src/popup/component.tsx) — owns `liveSettings` state, opens a long-lived `runtime.connect({ name: "popup" })` port, loads storage on mount, posts every `liveSettings` change to the background, renders **MessageEditor** (not HomeMenu).
-- Views under [`src/popup/views/messageEditor/`](../src/popup/views/messageEditor/) — active controls.
-- Shared controls under [`src/components/`](../src/components/) — Header, FormButtons, DeleteAllChatsButton, etc.
+-   [`src/popup/index.tsx`](../src/popup/index.tsx) — mounts `<Popup />` into `#popup`, imports global CSS.
+-   [`src/popup/component.tsx`](../src/popup/component.tsx) — owns `liveSettings` state, opens a long-lived `runtime.connect({ name: "popup" })` port, loads storage on mount, and posts `liveSettings` changes to the background after the initial load completes. It renders **MessageEditor** (not HomeMenu).
+-   Views under [`src/popup/views/messageEditor/`](../src/popup/views/messageEditor/) — active controls.
+-   Shared controls under [`src/components/`](../src/components/) — Header, FormButtons, DeleteAllChatsButton, etc.
 
-**Note:** `HomeMenu` and `MiscEditor` are still imported in `component.tsx` but are **not rendered**. Multi-page navigation was removed in changelog `1.1.0`; those views remain for tests and possible restoration.
+**Note:** `HomeMenu` and `MiscEditor` are retained in the source tree but are not imported or rendered by the live popup. Multi-page navigation was removed in changelog `1.1.0`; those views remain for tests and possible restoration.
 
 ### Background service worker
 
 [`src/backgroundPage.ts`](../src/backgroundPage.ts):
 
-1. Keeps `currentSettings` in memory (starts as `defaultSettings`).
+1. Seeds `currentSettings` from storage when the popup connects.
 2. Listens for `chrome.runtime.onConnect` with port name `"popup"`.
 3. On `message.type === 'updateSettings'`, updates `currentSettings`.
-4. On port disconnect (popup closed), calls `saveOptionsToStorage(currentSettings)`.
+4. On port disconnect (popup closed), saves only after settings have been loaded or received.
 
-This is the “save when popup closes” path. Explicit Save in the UI also writes storage (see caveats).
+This is the intentional “save when popup closes” path. Explicit Save in the UI also writes storage, allowing users to persist immediately without closing the popup.
 
 ### Content script
 
@@ -80,19 +80,19 @@ This is the “save when popup closes” path. Explicit Save in the UI also writ
 1. Creates `<style id="custom-style">` in `document.head`.
 2. Loads options from storage and sets `customStyle.textContent = updateStyles(settings)`.
 3. Listens for runtime messages:
-   - `action === "updateStyles"` → replace style text with `request.arg` (CSS string).
-   - `action === "deleteMessages"` → run `deleteAllChats()`, respond SUCCESS/FAILURE.
+    - `action === "updateStyles"` → replace style text with `request.arg` (CSS string).
+    - `action === "deleteMessages"` → run `deleteAllChats()`, respond SUCCESS/FAILURE.
 4. Periodically (every 1s) runs layout cleanup (`removeUnnecessarySpace`) and mounts `ScrollToTop` into ChatGPT’s presentation container if missing.
 
 ### Shared styling & storage
 
-| Module | Role |
-|--------|------|
-| [`googleStorage.ts`](../src/lib/utilities/googleStorage.ts) | `SettingsType`, get/set `options` under `chrome.storage.sync` |
-| [`data.ts`](../src/shared/utils/data.ts) | `defaultSettings` |
-| [`stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts) | `loadSettings`, `updateStyles`, `sendMessageToTab` |
-| [`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts) | Profile menu → Settings → delete-all click sequence |
-| [`removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | Remove Tailwind/layout classes that constrain width |
+| Module                                                                        | Role                                                          |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`googleStorage.ts`](../src/lib/utilities/googleStorage.ts)                   | `SettingsType`, get/set `options` under `chrome.storage.sync` |
+| [`data.ts`](../src/shared/utils/data.ts)                                      | `defaultSettings`                                             |
+| [`stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts)              | `loadSettings`, `updateStyles`, `sendMessageToTab`            |
+| [`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile menu → Settings → delete-all click sequence           |
+| [`removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | Remove Tailwind/layout classes that constrain width           |
 
 ## Communication flows
 
@@ -102,10 +102,10 @@ This is the “save when popup closes” path. Explicit Save in the UI also writ
 2. Control updates React state and calls `sendMessageToTab(settingKey, value)`.
 3. `sendMessageToTab` rebuilds the full CSS string via `updateStyles`, then:
 
-   ```ts
-   chrome.tabs.query({ active: true, currentWindow: true }, ...)
-   chrome.tabs.sendMessage(tabId, { action: "updateStyles", arg: cssTextContent })
-   ```
+    ```ts
+    chrome.tabs.query({ active: true, currentWindow: true }, ...)
+    chrome.tabs.sendMessage(tabId, { action: "updateStyles", arg: cssTextContent })
+    ```
 
 4. Content script writes the string into `#custom-style`.
 
@@ -115,12 +115,14 @@ This is the “save when popup closes” path. Explicit Save in the UI also writ
 
 Two paths write `chrome.storage.sync`:
 
-| Path | Trigger | Code |
-|------|---------|------|
-| Explicit Save | FormButtons Save | `saveOptionsToStorage(liveSettings)` |
-| Popup close | Port disconnect | Background `saveOptionsToStorage(currentSettings)` |
+| Path          | Trigger          | Code                                               |
+| ------------- | ---------------- | -------------------------------------------------- |
+| Explicit Save | FormButtons Save | `saveOptionsToStorage(liveSettings)`               |
+| Popup close   | Port disconnect  | Background `saveOptionsToStorage(currentSettings)` |
 
 `saveOptionsToStorage` also broadcasts `{ type: "SETTINGS_CHANGED", payload: options }` to all tabs. The content script **does not** listen for `SETTINGS_CHANGED` today; it only applies styles on load and via `updateStyles` messages. See caveats.
+
+Cancel restores the settings last loaded from storage or explicitly saved during the current popup session. Closing the popup without pressing Save intentionally persists the current live settings.
 
 ### Delete all conversations
 
@@ -146,9 +148,9 @@ sequenceDiagram
 
 ## Persistence model
 
-- Key: `options` in `chrome.storage.sync`.
-- Shape: [`SettingsType`](../src/lib/utilities/googleStorage.ts) (string numeric-looking values for widths/padding/radius; hex colors; one boolean for button visibility).
-- Defaults: [`defaultSettings`](../src/shared/utils/data.ts) when storage is empty.
+-   Key: `options` in `chrome.storage.sync`.
+-   Shape: [`SettingsType`](../src/lib/utilities/googleStorage.ts) (string numeric-looking values for widths/padding/radius; hex colors; one boolean for button visibility).
+-   Defaults: [`defaultSettings`](../src/shared/utils/data.ts), merged with storage so new/missing keys receive defaults.
 
 ## Known implementation caveats
 
@@ -157,14 +159,12 @@ These are **current code realities**, not goals:
 1. **Unused navigation UI** — `page` / `setPage` state and Header “Back” exist, but MessageEditor is always shown; HomeMenu/MiscEditor are dead runtime paths.
 2. **`SETTINGS_CHANGED` unused** — storage saver notifies tabs with `type: "SETTINGS_CHANGED"`; content script listens for `action: "updateStyles"` / `"deleteMessages"` only. Other tabs/pages do not auto-refresh from that broadcast.
 3. **Unmatched handshake messages** — content script sends `{ message: "Content script active" }` expecting `response.reply`, and the popup sends `{ popupMounted: true }` / port `{ popupOpened: true }`. The background has no `runtime.onMessage` handler for those; they are effectively no-ops (aside from port connect).
-4. **Dual save paths** — Save button writes immediately; closing the popup also saves whatever the background last received. Closing without Save can still persist live edits via the background path.
-5. **Race: Cancel vs async load** — MessageEditor initializes `savedSettings` from the first `liveSettings` prop (defaults). Storage loads asynchronously into `Popup`. Cancel before/without a Save can restore defaults instead of the previously persisted options.
-6. **Race: disconnect before load** — background `currentSettings` starts as `defaultSettings`. If the popup connects and disconnects before any `updateSettings` (or before the popup finishes loading storage), disconnect save may write defaults over stored options.
-7. **Delete button UX vs response** — DeleteAllChatsButton sets success after sending the message and does not reliably wait for / surface the content-script FAILURE response in all cases. Inside `deleteAllChats`, errors thrown from `setInterval` callbacks are outside the outer `try/catch`.
-8. **DOM fragility** — Styling and delete-all depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
+4. **Intentional dual save paths** — Save writes immediately; closing the popup also persists the current live settings.
+5. **Delete button UX vs response** — DeleteAllChatsButton sets success after sending the message and does not reliably wait for / surface the content-script FAILURE response in all cases. Inside `deleteAllChats`, errors thrown from `setInterval` callbacks are outside the outer `try/catch`.
+6. **DOM fragility** — Styling and delete-all depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
 
 ## Related docs
 
-- [features-and-settings.md](features-and-settings.md)
-- [development.md](development.md)
-- [../CLAUDE.md](../CLAUDE.md)
+-   [features-and-settings.md](features-and-settings.md)
+-   [development.md](development.md)
+-   [../CLAUDE.md](../CLAUDE.md)

--- a/docs/features-and-settings.md
+++ b/docs/features-and-settings.md
@@ -4,24 +4,24 @@ User-facing behavior and how settings become CSS on ChatGPT. Architecture contex
 
 ## Active features
 
-| Feature | Where | Behavior |
-|---------|-------|----------|
-| Message width | MessageEditor sliders | `%` max-width on conversation turns |
-| Message padding | MessageEditor sliders | `px` padding on message containers |
-| Message border radius | MessageEditor sliders | `px` border-radius |
-| Input box width | MessageEditor sliders | `%` max-width on `form` |
-| User / ChatGPT bubble colors | ColorControls | Background colors for odd/even turns |
-| User / ChatGPT text colors | ColorControls | Text colors for user vs assistant content |
-| Restore defaults / Save / Cancel | FormButtons | Reset preview, persist, or revert unsaved edits |
-| Delete all conversations | DeleteAllChatsButton | DOM automation on the active ChatGPT tab |
-| Scroll to top | Content script + ScrollToTop | Floating button when the thread is scrolled |
-| Layout cleanup | `removeUnnecessarySpace` | Removes classes that constrain width / alignment |
-| Fixed CSS helpers | `stylingFunctions` | Code-snippet width, transparent edit box, hide default message surface, etc. |
+| Feature                          | Where                        | Behavior                                                                      |
+| -------------------------------- | ---------------------------- | ----------------------------------------------------------------------------- |
+| Message width                    | MessageEditor sliders        | `%` max-width on conversation turns                                           |
+| Message padding                  | MessageEditor sliders        | `px` padding on message containers                                            |
+| Message border radius            | MessageEditor sliders        | `px` border-radius                                                            |
+| Input box width                  | MessageEditor sliders        | `%` max-width on `form`                                                       |
+| User / ChatGPT bubble colors     | ColorControls                | Background colors for odd/even turns                                          |
+| User / ChatGPT text colors       | ColorControls                | Text colors for user vs assistant content                                     |
+| Restore defaults / Save / Cancel | FormButtons                  | Reset preview, persist immediately, or restore the last saved/loaded settings |
+| Delete all conversations         | DeleteAllChatsButton         | DOM automation on the active ChatGPT tab                                      |
+| Scroll to top                    | Content script + ScrollToTop | Floating button when the thread is scrolled                                   |
+| Layout cleanup                   | `removeUnnecessarySpace`     | Removes classes that constrain width / alignment                              |
+| Fixed CSS helpers                | `stylingFunctions`           | Code-snippet width, transparent edit box, hide default message surface, etc.  |
 
 ### Retained but inactive UI
 
-- **HomeMenu** — button to open “Message Editor” (multi-page shell no longer used).
-- **MiscEditor** — checkbox for `messageButtonsVisibilityStyle` (show/hide chat message buttons). The setting still exists in `SettingsType` / CSS generation, but MiscEditor is not mounted in the live popup.
+-   **HomeMenu** — button to open “Message Editor” (multi-page shell no longer used).
+-   **MiscEditor** — checkbox for `messageButtonsVisibilityStyle` (show/hide chat message buttons). The setting still exists in `SettingsType` / CSS generation, but MiscEditor is not mounted in the live popup.
 
 Changelog `1.1.0` removed home/misc as the default navigation so MessageEditor is the sole popup view.
 
@@ -31,33 +31,33 @@ Defined in [`src/lib/utilities/googleStorage.ts`](../src/lib/utilities/googleSto
 
 ```ts
 interface SettingsType {
-  messageMaxWidthStyle: string;
-  messageColorUserStyle: string;
-  messageColorNonUserStyle: string;
-  messagePaddingStyle: string;
-  messageBorderRadiusStyle: string;
-  inputBoxMaxWidthStyle: string;
-  textColorUserStyle: string;
-  textColorNonUserStyle: string;
-  messageButtonsVisibilityStyle: boolean;
+    messageMaxWidthStyle: string;
+    messageColorUserStyle: string;
+    messageColorNonUserStyle: string;
+    messagePaddingStyle: string;
+    messageBorderRadiusStyle: string;
+    inputBoxMaxWidthStyle: string;
+    textColorUserStyle: string;
+    textColorNonUserStyle: string;
+    messageButtonsVisibilityStyle: boolean;
 }
 ```
 
 Defaults in [`src/shared/utils/data.ts`](../src/shared/utils/data.ts):
 
-| Key | Default |
-|-----|---------|
-| `messageMaxWidthStyle` | `"95"` |
-| `messageColorUserStyle` | `"#0084FF"` |
-| `messageColorNonUserStyle` | `"#333333"` |
-| `messagePaddingStyle` | `"10"` |
-| `messageBorderRadiusStyle` | `"5"` |
-| `inputBoxMaxWidthStyle` | `"94"` |
-| `textColorUserStyle` | `"#FFFFFF"` |
-| `textColorNonUserStyle` | `"#FFFFFF"` |
-| `messageButtonsVisibilityStyle` | `true` |
+| Key                             | Default     |
+| ------------------------------- | ----------- |
+| `messageMaxWidthStyle`          | `"95"`      |
+| `messageColorUserStyle`         | `"#0084FF"` |
+| `messageColorNonUserStyle`      | `"#333333"` |
+| `messagePaddingStyle`           | `"10"`      |
+| `messageBorderRadiusStyle`      | `"5"`       |
+| `inputBoxMaxWidthStyle`         | `"94"`      |
+| `textColorUserStyle`            | `"#FFFFFF"` |
+| `textColorNonUserStyle`         | `"#FFFFFF"` |
+| `messageButtonsVisibilityStyle` | `true`      |
 
-Storage key: `options` in `chrome.storage.sync`. Missing storage → clone of `defaultSettings`.
+Storage key: `options` in `chrome.storage.sync`. Stored values are merged over `defaultSettings`, so missing keys from older installs receive current defaults.
 
 ## Live preview vs Save / Cancel / Defaults
 
@@ -75,15 +75,15 @@ flowchart TD
 
 ### Control behavior
 
-- **Sliders** ([`MessageSliderControls`](../src/popup/views/messageEditor/components/messageSliderControls/component.tsx)): numeric text + range inputs (1–100). Digits only; values capped at 100. Each change calls `sendMessageToTab` and marks editing.
-- **Colors** ([`ColorControls`](../src/popup/views/messageEditor/components/colorControl/component.tsx)): HTML color inputs for User and ChatGPT × (BG, Text). Same live-update pattern.
-- **FormButtons** ([`FormButtons.tsx`](../src/components/formButtons/FormButtons.tsx)):
-  - **Restore Defaults** — set live state to `defaultSettings`, preview via `restoreSettings`, leave `isEditing` true.
-  - **Save** — `saveOptionsToStorage(liveSettings)`, copy into `savedSettings`, clear editing.
-  - **Cancel** — restore `savedSettings` into live state and preview; clear editing.
-- **Background disconnect** — even without clicking Save, closing the popup can persist the last `updateSettings` payload received by the background worker (see architecture caveats).
+-   **Sliders** ([`MessageSliderControls`](../src/popup/views/messageEditor/components/messageSliderControls/component.tsx)): numeric text + range inputs (1–100). Digits only; values capped at 100. Each change calls `sendMessageToTab` and marks editing.
+-   **Colors** ([`ColorControls`](../src/popup/views/messageEditor/components/colorControl/component.tsx)): HTML color inputs for User and ChatGPT × (BG, Text). Same live-update pattern.
+-   **FormButtons** ([`FormButtons.tsx`](../src/components/formButtons/FormButtons.tsx)):
+    -   **Restore Defaults** — set live state to `defaultSettings`, preview via `restoreSettings`, leave `isEditing` true.
+    -   **Save** — `saveOptionsToStorage(liveSettings)`, copy into `savedSettings`, clear editing.
+    -   **Cancel** — restore the settings last loaded from storage or explicitly saved, preview them, and clear editing.
+-   **Background disconnect** — closing the popup intentionally persists the latest live settings, even without clicking Save. The Save button provides an immediate persistence option while the popup remains open.
 
-`savedSettings` inside MessageEditor is initialized from the `liveSettings` prop at first render (defaults) and is only refreshed when the user clicks Save — it is **not** updated when storage finishes loading into `Popup`. Cancel before an explicit Save can therefore restore defaults rather than the previously persisted options (see [architecture caveats](architecture.md#known-implementation-caveats)).
+The popup does not forward its initial defaults to the background until storage finishes loading. This prevents a quick open/close from overwriting stored settings with defaults.
 
 ## CSS generation
 
@@ -93,20 +93,20 @@ flowchart TD
 2. `loadSettings(settings)` walks the settings object and invokes each controller (truthy values only — note that `false` for `messageButtonsVisibilityStyle` is skipped by `if (newSettings[setting])`).
 3. `updateStyles(setting, newValue?)` either loads a full object or updates one key, then concatenates:
 
-   - Dynamic fragments (width, padding, radius, colors, button visibility, …)
-   - Fixed fragments (code snippet width, hide default surface background, show edit button, max bubble width, transparent edit box, input padding/max-width resets)
+    - Dynamic fragments (width, padding, radius, colors, button visibility, …)
+    - Fixed fragments (code snippet width, hide default surface background, show edit button, max bubble width, transparent edit box, input padding/max-width resets)
 
 4. Primary selector root: `[data-testid^="conversation-turn-"]`.
-   - User turns: `:nth-child(odd)`
-   - Assistant turns: `:nth-child(even)`
+    - User turns: `:nth-child(odd)`
+    - Assistant turns: `:nth-child(even)`
 
 ### Messaging helper
 
 `sendMessageToTab(action, value)`:
 
-- `action === "restoreSettings"` + settings object → full CSS from that object.
-- Otherwise treats `action` as a `keyof SettingsType` and updates that key before sending.
-- Always sends `{ action: "updateStyles", arg: cssString }` to the active tab.
+-   `action === "restoreSettings"` + settings object → full CSS from that object.
+-   Otherwise treats `action` as a `keyof SettingsType` and updates that key before sending.
+-   Always sends `{ action: "updateStyles", arg: cssString }` to the active tab.
 
 Content script applies `arg` as `customStyle.textContent` — it does not re-parse settings for live updates.
 
@@ -114,9 +114,9 @@ Content script applies `arg` as `customStyle.textContent` — it does not re-par
 
 [`src/components/scrollToTop/scrollToTop.tsx`](../src/components/scrollToTop/scrollToTop.tsx), mounted by the content script:
 
-- Finds ChatGPT’s scroll container under `div[role="presentation"] > ...`.
-- Shows a circular button when `scrollTop !== 0`.
-- Smooth-scrolls to top; hides the button while scrolling.
+-   Finds ChatGPT’s scroll container under `div[role="presentation"] > ...`.
+-   Shows a circular button when `scrollTop !== 0`.
+-   Smooth-scrolls to top; hides the button while scrolling.
 
 Remount logic runs on a 1s interval so SPA navigations between chats still get the button.
 
@@ -141,6 +141,6 @@ Treat this feature as **fragile**; selector failures are expected after ChatGPT 
 
 ## Related docs
 
-- [architecture.md](architecture.md)
-- [dom-integration.md](dom-integration.md)
-- [../CLAUDE.md](../CLAUDE.md)
+-   [architecture.md](architecture.md)
+-   [dom-integration.md](dom-integration.md)
+-   [../CLAUDE.md](../CLAUDE.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chatgpt-styler",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chatgpt-styler",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "license": "MIT",
             "dependencies": {
                 "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chatgpt-styler",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Extension to allow users to change the styling for their ChatGPT experience.",
     "main": "index.js",
     "packageManager": "npm@11.16.0",

--- a/src/backgroundPage.ts
+++ b/src/backgroundPage.ts
@@ -1,28 +1,42 @@
-import { saveOptionsToStorage } from "./lib/utilities/googleStorage";
-import { defaultSettings } from "./shared/utils/data";
+import {
+    getOptionsFromStorage,
+    saveOptionsToStorage,
+    SettingsType,
+} from "./lib/utilities/googleStorage";
 
-let currentSettings = defaultSettings;
+let currentSettings: SettingsType | null = null;
+let receivedFromPopup = false;
 
 chrome.runtime.onConnect.addListener((port) => {
     console.assert(port.name === "popup");
+
+    // Seed from storage so a quick close before the popup sends updates
+    // does not persist in-memory defaults over the user's saved options.
+    getOptionsFromStorage((savedOptions) => {
+        if (!receivedFromPopup) {
+            currentSettings = savedOptions;
+        }
+    });
+
     port.onMessage.addListener((message) => {
         if (message.popupOpened) {
             console.log("Popup opened");
-            // Optionally, initialize or send current settings to the popup
         } else if (message.type === "updateSettings") {
             console.log(
                 "Received updated settings from popup:",
                 message.settings,
             );
             currentSettings = message.settings;
+            receivedFromPopup = true;
         }
-        // You can also respond or send messages to the popup here
     });
 
     port.onDisconnect.addListener(() => {
         console.log("Popup closed. Settings are now:", currentSettings);
-        // Call saveOptionsToStorage with the most recent settings state
-        saveOptionsToStorage(currentSettings);
-        // Note: Ensure `saveOptionsToStorage` is properly adapted to handle Promises if asynchronous
+        // Intentional autosave-on-close. Skip only if we never learned any settings.
+        if (currentSettings !== null) {
+            saveOptionsToStorage(currentSettings);
+        }
+        receivedFromPopup = false;
     });
 });

--- a/src/lib/utilities/googleStorage.ts
+++ b/src/lib/utilities/googleStorage.ts
@@ -16,7 +16,10 @@ export const getOptionsFromStorage = (
     callback: (options: SettingsType) => void,
 ): void => {
     chrome.storage.sync.get(["options"], (result) => {
-        const options = result.options || { ...defaultSettings };
+        const options: SettingsType = {
+            ...defaultSettings,
+            ...(result.options || {}),
+        };
         callback(options);
         console.log("GETTING OPTIONS FROM STORAGE", options);
     });

--- a/src/popup/component.tsx
+++ b/src/popup/component.tsx
@@ -17,11 +17,12 @@ export function Popup(): JSX.Element {
     const [liveSettings, setLiveSettings] = useState<SettingsType>({
         ...defaultSettings,
     });
+    const [settingsLoaded, setSettingsLoaded] = useState(false);
     const [page, setPage] = useState<string>("Home");
 
     const sendSettingsToBackground = (updatedSettings: SettingsType) => {
         try {
-            console.log("sending settings to background", liveSettings);
+            console.log("sending settings to background", updatedSettings);
             port.postMessage({
                 type: "updateSettings",
                 settings: updatedSettings,
@@ -31,9 +32,12 @@ export function Popup(): JSX.Element {
         }
     };
 
+    // Only mirror settings to the background after storage has loaded.
+    // Avoids saving defaultSettings if the popup closes during the initial race.
     useEffect(() => {
+        if (!settingsLoaded) return;
         sendSettingsToBackground(liveSettings);
-    }, [liveSettings]);
+    }, [liveSettings, settingsLoaded]);
 
     useEffect(() => {
         port.postMessage({ popupOpened: true });
@@ -41,6 +45,7 @@ export function Popup(): JSX.Element {
         getOptionsFromStorage((savedOptions) => {
             setLiveSettings(savedOptions);
             loadSettings(savedOptions);
+            setSettingsLoaded(true);
             console.log("loaded options from storage", savedOptions);
         });
         return () => {

--- a/src/popup/views/messageEditor/__tests__/messageEditor.test.tsx
+++ b/src/popup/views/messageEditor/__tests__/messageEditor.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import renderer, { ReactTestRenderer } from "react-test-renderer";
+import renderer, { act, ReactTestRenderer } from "react-test-renderer";
 import { MessageEditor, MessageEditorProps } from "../index";
 import { MessageSliderControls } from "../components/messageSliderControls";
 import { ColorControls } from "../components/colorControl/component";
+import { FormButtons } from "@src/components/formButtons/FormButtons";
 
 jest.mock("@src/shared/utils", () => ({
     sendMessageToTab: jest.fn(),
@@ -57,5 +58,38 @@ describe("MessageEditor Component", () => {
 
         expect(slider.props.liveChanges).toEqual(mockProps.liveSettings);
         expect(slider.props.setLiveChanges).toBe(mockProps.setLiveSettings);
+    });
+
+    it("restores storage-loaded settings when Cancel is clicked", () => {
+        const loadedSettings = {
+            ...mockProps.liveSettings,
+            messageMaxWidthStyle: "72",
+            messageColorUserStyle: "#123456",
+        };
+
+        act(() => {
+            component.update(
+                <MessageEditor
+                    liveSettings={loadedSettings}
+                    setLiveSettings={mockProps.setLiveSettings}
+                />,
+            );
+        });
+
+        act(() => {
+            component.root.findByType(FormButtons).props.setIsEditing(true);
+        });
+
+        const cancelButton = component.root
+            .findAllByType("button")
+            .find((button) => button.children.includes("Cancel"));
+
+        if (!cancelButton) throw new Error("Cancel button not found");
+
+        act(() => {
+            cancelButton.props.onClick();
+        });
+
+        expect(mockProps.setLiveSettings).toHaveBeenCalledWith(loadedSettings);
     });
 });

--- a/src/popup/views/messageEditor/component.tsx
+++ b/src/popup/views/messageEditor/component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { SettingsType } from "@src/lib/utilities/googleStorage";
 import { ColorControls } from "./components/colorControl/component";
 import { FormButtons } from "@src/components/formButtons/FormButtons";
@@ -17,6 +17,14 @@ export function MessageEditor({
     const [savedSettings, setSavedSettings] = useState<SettingsType>({
         ...liveSettings,
     });
+
+    // Keep Cancel's baseline in sync with storage-loaded / saved settings.
+    // While editing, leave savedSettings alone so Cancel can restore them.
+    useEffect(() => {
+        if (!isEditing) {
+            setSavedSettings({ ...liveSettings });
+        }
+    }, [liveSettings, isEditing]);
 
     return (
         <div


### PR DESCRIPTION
- Fixed Cancel restoring defaults instead of saved settings
- Prevented popup load/close settings overwrite race
- Preserved intentional Save-or-close persistence
- Added safe defaults for older stored settings
- Added regression coverage and updated documentation
- Bumped patch version to 1.2.4 and updated changelog

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
