### PR TITLE
Harden Content Script DOM Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 -   Prevented a race where closing the popup before settings finished loading could overwrite saved options with defaults
 -   Merged stored settings with defaults so missing keys from older installs are filled in
 -   Applied `messageButtonsVisibilityStyle: false` correctly after settings reload
+-   Prevented content-script console errors when ChatGPT layout nodes are missing
+-   Made scroll-to-top remount correctly when ChatGPT replaces its scroll container
 
 ### Changed
 
 -   Made CSS generation deterministic by building styles from the complete settings object
 -   Added regression coverage for generated CSS and boolean settings
+-   Hardened the content-script 1s integration loop to skip missing DOM and avoid stale mounts
+-   Removed an unused content-script handshake message
 
 ## [1.2.3] - 2025-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Full flow: [docs/architecture.md](docs/architecture.md). Settings model: [docs/f
 -   Target host is **`chatgpt.com`** only ([`dist/manifest.json`](dist/manifest.json) `host_permissions` / `content_scripts`).
 -   Permissions in use: `activeTab`, `storage`. Avoid new permissions unless product requires them.
 -   CSS is applied by writing a **string** into `#custom-style`. Selector drift on ChatGPT’s DOM is the #1 breakage mode.
--   `contentScript` remounts / re-applies layout helpers on a **1s interval** — be careful adding heavier work there.
+-   `contentScript` re-applies layout helpers and keeps ScrollToTop mounted on a **1s interval** — null-safe, but still avoid heavier work there.
 -   Built JS lands in `dist/js/` (typically gitignored after build); static assets (`manifest.json`, `popup.html`, icons) are **tracked release inputs** under `dist/` and are **not** emitted by Webpack. Never delete tracked static `dist` files; never hand-edit generated `dist/js/*`.
 
 ## Change checklists

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ This is the intentional “save when popup closes” path. Explicit Save in the 
 3. Listens for runtime messages:
     - `action === "updateStyles"` → replace style text with `request.arg` (CSS string).
     - `action === "deleteMessages"` → run `deleteAllChats()`, respond SUCCESS/FAILURE.
-4. Periodically (every 1s) runs layout cleanup (`removeUnnecessarySpace`) and mounts `ScrollToTop` into ChatGPT’s presentation container if missing.
+4. Periodically (every 1s) runs layout cleanup (`removeUnnecessarySpace`) and keeps `ScrollToTop` mounted on the current ChatGPT scroll container. Missing DOM nodes are skipped; stale mounts are cleaned up when the parent is replaced.
 
 ### Shared styling & storage
 
@@ -92,6 +92,7 @@ This is the intentional “save when popup closes” path. Explicit Save in the 
 | [`data.ts`](../src/shared/utils/data.ts)                                      | `defaultSettings`                                              |
 | [`stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts)              | Pure `buildCss(settings)`, `sendMessageToTab` for live preview |
 | [`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile menu → Settings → delete-all click sequence            |
+| [`chatDom.ts`](../src/lib/utilities/chatDom.ts)                               | Shared ChatGPT DOM selectors / mount ids                       |
 | [`removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | Remove Tailwind/layout classes that constrain width            |
 
 ## Communication flows
@@ -158,7 +159,7 @@ These are **current code realities**, not goals:
 
 1. **Unused navigation UI** — `page` / `setPage` state and Header “Back” exist, but MessageEditor is always shown; HomeMenu/MiscEditor are dead runtime paths.
 2. **`SETTINGS_CHANGED` unused** — storage saver notifies tabs with `type: "SETTINGS_CHANGED"`; content script listens for `action: "updateStyles"` / `"deleteMessages"` only. Other tabs/pages do not auto-refresh from that broadcast.
-3. **Unmatched handshake messages** — content script sends `{ message: "Content script active" }` expecting `response.reply`, and the popup sends `{ popupMounted: true }` / port `{ popupOpened: true }`. The background has no `runtime.onMessage` handler for those; they are effectively no-ops (aside from port connect).
+3. **Unmatched handshake messages** — the popup sends `{ popupMounted: true }` / port `{ popupOpened: true }`. The background has no `runtime.onMessage` handler for those; they are effectively no-ops (aside from port connect).
 4. **Intentional dual save paths** — Save writes immediately; closing the popup also persists the current live settings.
 5. **Delete button UX vs response** — DeleteAllChatsButton sets success after sending the message and does not reliably wait for / surface the content-script FAILURE response in all cases. Inside `deleteAllChats`, errors thrown from `setInterval` callbacks are outside the outer `try/catch`.
 6. **DOM fragility** — Styling and delete-all depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).

--- a/docs/dom-integration.md
+++ b/docs/dom-integration.md
@@ -7,23 +7,24 @@ ChatGPT Styler depends heavily on ChatGPT’s page structure. When OpenAI change
 -   Content script CSS targets deep, often nth-child-based selectors.
 -   Delete-all **clicks through ChatGPT’s own UI** rather than calling an official API.
 -   Layout helpers **remove site classes** by name (`max-w-(--thread-content-max-width)`, `items-end`, etc.).
--   Remount / cleanup runs on a **1-second interval**, so broken selectors may fail quietly until you inspect the page.
+-   Remount / cleanup runs on a **1-second interval**. Missing nodes are skipped (no throw). Broken selectors may still fail quietly until you inspect the page.
 
 Always prefer updating selectors in the smallest surface that broke, then smoke-test light + dark themes.
 
 ## Files that touch the DOM
 
-| File                                                                                            | Responsibility                                                 |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`src/contentScript.ts`](../src/contentScript.ts)                                               | Style tag, message listeners, mount loop, query for containers |
-| [`src/shared/utils/stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts)               | CSS selectors for conversation turns, form, composer           |
-| [`src/lib/utilities/removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | ClassList removals on message / input containers               |
-| [`src/lib/utilities/deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile → Settings → delete-all automation                     |
-| [`src/components/scrollToTop/scrollToTop.tsx`](../src/components/scrollToTop/scrollToTop.tsx)   | Scroll container + injected button                             |
+| File                                                                                            | Responsibility                                            |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [`src/contentScript.ts`](../src/contentScript.ts)                                               | Style tag, message listeners, null-safe mount/layout loop |
+| [`src/lib/utilities/chatDom.ts`](../src/lib/utilities/chatDom.ts)                               | Shared ChatGPT DOM selectors / mount ids                  |
+| [`src/shared/utils/stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts)               | CSS selectors for conversation turns, form, composer      |
+| [`src/lib/utilities/removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | ClassList removals on message / input containers          |
+| [`src/lib/utilities/deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile → Settings → delete-all automation                |
+| [`src/components/scrollToTop/scrollToTop.tsx`](../src/components/scrollToTop/scrollToTop.tsx)   | Scroll container + injected button                        |
 
 ## Selector catalog
 
-### Content script mount & layout ([`contentScript.ts`](../src/contentScript.ts))
+### Content script mount & layout ([`contentScript.ts`](../src/contentScript.ts) / [`chatDom.ts`](../src/lib/utilities/chatDom.ts))
 
 | Purpose              | Selector / target                                                                  |
 | -------------------- | ---------------------------------------------------------------------------------- |

--- a/docs/features-and-settings.md
+++ b/docs/features-and-settings.md
@@ -116,7 +116,7 @@ Content script applies `arg` as `customStyle.textContent` — it does not re-par
 -   Shows a circular button when `scrollTop !== 0`.
 -   Smooth-scrolls to top; hides the button while scrolling.
 
-Remount logic runs on a 1s interval so SPA navigations between chats still get the button.
+Remount logic runs on a 1s interval so SPA navigations between chats still get the button. If ChatGPT replaces the scroll container, the old mount is removed and a fresh `ScrollToTop` is attached.
 
 ## Delete all conversations
 

--- a/src/components/scrollToTop/scrollToTop.tsx
+++ b/src/components/scrollToTop/scrollToTop.tsx
@@ -1,54 +1,51 @@
 import React, { useState, useEffect } from "react";
+import { CHAT_SCROLL_PARENT_SELECTOR } from "@src/lib/utilities/chatDom";
 
-export const ScrollToTop = () => {
+const getScrollParent = (): HTMLElement | null => {
+    const node = document.querySelector(CHAT_SCROLL_PARENT_SELECTOR);
+    return node instanceof HTMLElement ? node : null;
+};
+
+export const ScrollToTop = (): JSX.Element => {
     const [isShowingScrollToTopButton, setIsShowingScrollToTopButton] =
-        useState<boolean | null>(null);
-    const [isScrollingToTop, setIsScrollingToTop] = useState<boolean | null>(
-        false,
-    );
-    const parentDiv = document.querySelector(
-        'div[role="presentation"] > div > div > div > div',
-    );
+        useState(false);
+    const [isScrollingToTop, setIsScrollingToTop] = useState(false);
 
     useEffect(() => {
+        const parentDiv = getScrollParent();
+        if (!parentDiv) return;
+
         const handleScroll = () => {
-            if (!parentDiv) return;
-            // If the scrollTop is 0, the user is at the top of the page
             if (!parentDiv.scrollTop) {
                 setIsScrollingToTop(false);
                 setIsShowingScrollToTopButton(false);
             } else {
-                // Otherwise, the button should be visible
                 setIsShowingScrollToTopButton(true);
             }
         };
 
-        const handleScrollEnd = () => setIsScrollingToTop(false); // Reset isScrollingToTop after scroll ends
+        const handleScrollEnd = () => setIsScrollingToTop(false);
 
-        if (!parentDiv) return;
-
-        // Initial check for scrollTop when the component mounts and when the user changes conversation threads
         handleScroll();
 
         parentDiv.addEventListener("scroll", handleScroll);
-        parentDiv.addEventListener("scrollend", handleScrollEnd); // Event listener for the end of the scroll
+        parentDiv.addEventListener("scrollend", handleScrollEnd);
         return () => {
             parentDiv.removeEventListener("scroll", handleScroll);
             parentDiv.removeEventListener("scrollend", handleScrollEnd);
         };
     }, []);
 
-    const scrollToTop = () => {
+    const scrollToTop = (): void => {
+        const parentDiv = getScrollParent();
+        if (!parentDiv) return;
         setIsShowingScrollToTopButton(false);
         setIsScrollingToTop(true);
-        parentDiv!.scrollTo({ top: 0, behavior: "smooth" });
+        parentDiv.scrollTo({ top: 0, behavior: "smooth" });
     };
 
     return (
         <>
-            {/* This is only rendered if the user is scrolled down and the user is
-            not currently scrolling to the top. The button is hidden during the
-            scroll to prevent more clicks. */}
             {isShowingScrollToTopButton && !isScrollingToTop && (
                 <button
                     className={
@@ -56,6 +53,8 @@ export const ScrollToTop = () => {
                     }
                     onClick={scrollToTop}
                     id="scroll-to-top-btn"
+                    type="button"
+                    aria-label="Scroll to top"
                 >
                     <UpArrow />
                 </button>
@@ -64,7 +63,7 @@ export const ScrollToTop = () => {
     );
 };
 
-const UpArrow = () => {
+const UpArrow = (): JSX.Element => {
     return (
         <svg
             width="24"
@@ -73,6 +72,7 @@ const UpArrow = () => {
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
             className="icon-md text-token-text-primary"
+            aria-hidden="true"
         >
             <path
                 fillRule="evenodd"

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -4,6 +4,12 @@ import { ScrollToTop } from "./components/scrollToTop/scrollToTop";
 import { getOptionsFromStorage, deleteAllChats } from "./lib/utilities";
 import { buildCss } from "./shared/utils";
 import { removeUnnecessarySpace } from "@src/lib/utilities";
+import {
+    CHAT_SCROLL_PARENT_SELECTOR,
+    INPUT_BOX_CONTAINER_SELECTOR,
+    SCROLL_TO_TOP_MOUNT_ID,
+    USER_TEXT_CONTAINER_SELECTOR,
+} from "@src/lib/utilities/chatDom";
 
 console.log("Content script loaded.");
 
@@ -15,7 +21,6 @@ getOptionsFromStorage(
     (settings) => (customStyle.textContent = buildCss(settings)),
 );
 
-// listening for messages from the background script or popup
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "updateStyles") {
         customStyle.textContent = request.arg;
@@ -31,39 +36,51 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
 });
 
-// send a message to the background script if needed
-chrome.runtime.sendMessage({ message: "Content script active" }, (response) => {
-    console.log(response.reply);
-});
-const mountComponent = () => {
-    const mountPoint = document.createElement("div");
-    mountPoint.id = "scroll-to-top-mount";
-
-    const userTextContainer: any = document.querySelectorAll(
-        '[data-testid^="conversation-turn-"]:nth-child(odd) > * > * > * > * > * > * > div',
+const syncLayoutHelpers = (): void => {
+    const userTextContainer = document.querySelectorAll(
+        USER_TEXT_CONTAINER_SELECTOR,
     );
-
-    const inputBoxContainer: any = document.querySelector(
-        "#thread-bottom > * > div",
+    const inputBoxContainer = document.querySelector(
+        INPUT_BOX_CONTAINER_SELECTOR,
     );
 
     removeUnnecessarySpace({ userTextContainer, inputBoxContainer });
+};
 
-    if (!document.getElementById("scroll-to-top-mount")) {
-        const $parentDiv = document.querySelector(
-            'div[role="presentation"] > div > div > div > div ',
-        );
-        if ($parentDiv) {
-            $parentDiv.appendChild(mountPoint);
-            ReactDOM.render(React.createElement(ScrollToTop), mountPoint);
+const unmountScrollToTop = (mountPoint: Element): void => {
+    ReactDOM.unmountComponentAtNode(mountPoint);
+    mountPoint.remove();
+};
+
+const syncScrollToTop = (): void => {
+    const parentDiv = document.querySelector(CHAT_SCROLL_PARENT_SELECTOR);
+    const existingMount = document.getElementById(SCROLL_TO_TOP_MOUNT_ID);
+
+    if (!(parentDiv instanceof HTMLElement)) {
+        if (existingMount) {
+            unmountScrollToTop(existingMount);
         }
+        return;
     }
+
+    if (existingMount && parentDiv.contains(existingMount)) {
+        return;
+    }
+
+    if (existingMount) {
+        unmountScrollToTop(existingMount);
+    }
+
+    const mountPoint = document.createElement("div");
+    mountPoint.id = SCROLL_TO_TOP_MOUNT_ID;
+    parentDiv.appendChild(mountPoint);
+    ReactDOM.render(React.createElement(ScrollToTop), mountPoint);
 };
 
-const checkAndMountComponent = () => {
-    mountComponent();
+const syncPageIntegrations = (): void => {
+    syncLayoutHelpers();
+    syncScrollToTop();
 };
 
-checkAndMountComponent();
-
-setInterval(checkAndMountComponent, 1000);
+syncPageIntegrations();
+setInterval(syncPageIntegrations, 1000);

--- a/src/lib/utilities/__tests__/removeUnnecessarySpace.test.ts
+++ b/src/lib/utilities/__tests__/removeUnnecessarySpace.test.ts
@@ -1,0 +1,33 @@
+import { removeUnnecessarySpace } from "../removeUnnecessarySpace";
+
+describe("removeUnnecessarySpace", () => {
+    it("no-ops when the input box container is missing", () => {
+        expect(() =>
+            removeUnnecessarySpace({
+                userTextContainer: [],
+                inputBoxContainer: null,
+            }),
+        ).not.toThrow();
+    });
+
+    it("removes layout classes when nodes are present", () => {
+        const inputBoxContainer = document.createElement("div");
+        inputBoxContainer.className =
+            "max-w-(--thread-content-max-width) gap-4 md:gap-5 lg:gap-6";
+
+        const userTextContainer = document.createElement("div");
+        userTextContainer.className = "items-end";
+        const child = document.createElement("div");
+        child.className = "px-5";
+        userTextContainer.appendChild(child);
+
+        removeUnnecessarySpace({
+            userTextContainer: [userTextContainer],
+            inputBoxContainer,
+        });
+
+        expect(inputBoxContainer.className).toBe("");
+        expect(userTextContainer.classList.contains("items-end")).toBe(false);
+        expect(child.classList.contains("px-5")).toBe(false);
+    });
+});

--- a/src/lib/utilities/chatDom.ts
+++ b/src/lib/utilities/chatDom.ts
@@ -1,0 +1,9 @@
+export const CHAT_SCROLL_PARENT_SELECTOR =
+    'div[role="presentation"] > div > div > div > div';
+
+export const USER_TEXT_CONTAINER_SELECTOR =
+    '[data-testid^="conversation-turn-"]:nth-child(odd) > * > * > * > * > * > * > div';
+
+export const INPUT_BOX_CONTAINER_SELECTOR = "#thread-bottom > * > div";
+
+export const SCROLL_TO_TOP_MOUNT_ID = "scroll-to-top-mount";

--- a/src/lib/utilities/index.ts
+++ b/src/lib/utilities/index.ts
@@ -1,3 +1,4 @@
 export * from "./deleteAllChats";
 export * from "./googleStorage";
 export * from "./removeUnnecessarySpace";
+export * from "./chatDom";

--- a/src/lib/utilities/removeUnnecessarySpace.ts
+++ b/src/lib/utilities/removeUnnecessarySpace.ts
@@ -1,21 +1,26 @@
-interface removeUnnecessarySpaceTypes {
-    userTextContainer: HTMLElement[];
-    inputBoxContainer: HTMLDivElement;
+interface RemoveUnnecessarySpaceTypes {
+    userTextContainer: ArrayLike<Element>;
+    inputBoxContainer: Element | null;
 }
 
 export const removeUnnecessarySpace = ({
     userTextContainer,
     inputBoxContainer,
-}: removeUnnecessarySpaceTypes): void => {
-    inputBoxContainer.classList.remove("max-w-(--thread-content-max-width)");
-    inputBoxContainer.classList.remove("gap-4");
-    inputBoxContainer.classList.remove("md:gap-5");
-    inputBoxContainer.classList.remove("lg:gap-6");
+}: RemoveUnnecessarySpaceTypes): void => {
+    if (inputBoxContainer instanceof HTMLElement) {
+        inputBoxContainer.classList.remove(
+            "max-w-(--thread-content-max-width)",
+        );
+        inputBoxContainer.classList.remove("gap-4");
+        inputBoxContainer.classList.remove("md:gap-5");
+        inputBoxContainer.classList.remove("lg:gap-6");
+    }
 
-    userTextContainer.forEach((element) => {
+    Array.from(userTextContainer).forEach((element) => {
+        if (!(element instanceof HTMLElement)) return;
         element.classList.remove("items-end");
-        const firstChild = element.children[0] as HTMLElement | undefined;
-        if (firstChild) {
+        const firstChild = element.children[0];
+        if (firstChild instanceof HTMLElement) {
             firstChild.classList.remove("px-5");
         }
     });


### PR DESCRIPTION
- Made layout cleanup null-safe when ChatGPT nodes are missing
- Remounted scroll-to-top only when needed and cleaned up stale mounts
- Shared ChatGPT DOM selectors in one place
- Removed an unused content-script handshake
- Added regression tests and documentation updates

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
