### PR TITLE
Harden delete-all so success/failure match the real DOM flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 -   Applied `messageButtonsVisibilityStyle: false` correctly after settings reload
 -   Prevented content-script console errors when ChatGPT layout nodes are missing
 -   Made scroll-to-top remount correctly when ChatGPT replaces its scroll container
+-   Made delete-all report success only after the ChatGPT UI flow completes
+-   Stopped delete-all polling from throwing forever when buttons never appear
 
 ### Changed
 
@@ -17,6 +19,7 @@
 -   Added regression coverage for generated CSS and boolean settings
 -   Hardened the content-script 1s integration loop to skip missing DOM and avoid stale mounts
 -   Removed an unused content-script handshake message
+-   Delete-all now awaits the content-script result and uses a hostname-based ChatGPT tab check
 
 ## [1.2.3] - 2025-06-25
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ This is the intentional “save when popup closes” path. Explicit Save in the 
 2. Loads options from storage and sets `customStyle.textContent = buildCss(settings)`.
 3. Listens for runtime messages:
     - `action === "updateStyles"` → replace style text with `request.arg` (CSS string).
-    - `action === "deleteMessages"` → run `deleteAllChats()`, respond SUCCESS/FAILURE.
+    - `action === "deleteMessages"` → run async `deleteAllChats()`, respond SUCCESS/FAILURE when finished.
 4. Periodically (every 1s) runs layout cleanup (`removeUnnecessarySpace`) and keeps `ScrollToTop` mounted on the current ChatGPT scroll container. Missing DOM nodes are skipped; stale mounts are cleaned up when the parent is replaced.
 
 ### Shared styling & storage
@@ -127,9 +127,10 @@ Cancel restores the settings last loaded from storage or explicitly saved during
 
 ### Delete all conversations
 
-1. [`DeleteAllChatsButton`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx) confirms, checks active tab URL contains `chatgpt.com`.
+1. [`DeleteAllChatsButton`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx) confirms, checks the active tab hostname is `chatgpt.com`.
 2. Sends `{ action: "deleteMessages" }` to that tab.
-3. Content script runs `deleteAllChats()` against live DOM and `sendResponse`s status.
+3. Content script runs async `deleteAllChats()` against live DOM (bounded waits, cleaned-up timers) and `sendResponse`s SUCCESS/FAILURE.
+4. Popup shows success or the failure message from that response.
 
 ### Popup ↔ background port
 
@@ -161,8 +162,8 @@ These are **current code realities**, not goals:
 2. **`SETTINGS_CHANGED` unused** — storage saver notifies tabs with `type: "SETTINGS_CHANGED"`; content script listens for `action: "updateStyles"` / `"deleteMessages"` only. Other tabs/pages do not auto-refresh from that broadcast.
 3. **Unmatched handshake messages** — the popup sends `{ popupMounted: true }` / port `{ popupOpened: true }`. The background has no `runtime.onMessage` handler for those; they are effectively no-ops (aside from port connect).
 4. **Intentional dual save paths** — Save writes immediately; closing the popup also persists the current live settings.
-5. **Delete button UX vs response** — DeleteAllChatsButton sets success after sending the message and does not reliably wait for / surface the content-script FAILURE response in all cases. Inside `deleteAllChats`, errors thrown from `setInterval` callbacks are outside the outer `try/catch`.
-6. **DOM fragility** — Styling and delete-all depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
+5. **Delete-all DOM fragility** — automation still depends on ChatGPT’s menu markup and can time out when selectors drift; failures are now reported honestly instead of as false success. See [dom-integration.md](dom-integration.md).
+6. **General DOM fragility** — Styling and layout helpers also depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
 
 ## Related docs
 

--- a/docs/dom-integration.md
+++ b/docs/dom-integration.md
@@ -79,23 +79,23 @@ Uses site design tokens in button classes (`border-token-border-light`, `bg-toke
 
 Comments in source note that selectors may need updates after domain HTML changes.
 
-| Step                   | Selector / action                                             |
-| ---------------------- | ------------------------------------------------------------- |
-| Detect history present | `div.group\\/sidebar > div:nth-child(3)` (must have children) |
-| Open profile           | `[aria-label="Open Profile Menu"]` via pointerdown/pointerup  |
-| Open settings          | `[data-testid="settings-menu-item"]` click                    |
-| Delete all             | `[data-testid="delete-all-chats-button"]` (polled)            |
-| Confirm                | `[data-testid="confirm-delete-all-chats-button"]` (polled)    |
+| Step                   | Selector / action                                              |
+| ---------------------- | -------------------------------------------------------------- |
+| Detect history present | `div.group\\/sidebar > div:nth-child(3)` (must have children)  |
+| Open profile           | `[aria-label="Open Profile Menu"]` via pointerdown/pointerup   |
+| Open settings          | `[data-testid="settings-menu-item"]` click                     |
+| Delete all             | `[data-testid="delete-all-chats-button"]` (awaited, timed out) |
+| Confirm                | `[data-testid="confirm-delete-all-chats-button"]` (awaited)    |
 
-Popup gate: active tab URL slice must equal `chatgpt.com` ([`DeleteAllChatsButton.tsx`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx)).
+Popup gate: active tab hostname is `chatgpt.com` / `*.chatgpt.com` ([`DeleteAllChatsButton.tsx`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx)). Automation uses bounded waits and always clears timers; SUCCESS is only returned after the confirm click.
 
 ## Message contracts that affect the page
 
-| Message                                   | Direction         | Content script effect                           |
-| ----------------------------------------- | ----------------- | ----------------------------------------------- |
-| `{ action: "updateStyles", arg: string }` | Popup → CS        | Replace `#custom-style` text                    |
-| `{ action: "deleteMessages" }`            | Popup → CS        | Run `deleteAllChats()`; respond SUCCESS/FAILURE |
-| `{ type: "SETTINGS_CHANGED", payload }`   | Background → tabs | **Not handled** by content script today         |
+| Message                                   | Direction         | Content script effect                                               |
+| ----------------------------------------- | ----------------- | ------------------------------------------------------------------- |
+| `{ action: "updateStyles", arg: string }` | Popup → CS        | Replace `#custom-style` text                                        |
+| `{ action: "deleteMessages" }`            | Popup → CS        | Run async `deleteAllChats()`; respond SUCCESS/FAILURE when finished |
+| `{ type: "SETTINGS_CHANGED", payload }`   | Background → tabs | **Not handled** by content script today                             |
 
 On load, CS still applies styles from `getOptionsFromStorage` → `buildCss(settings)`.
 

--- a/docs/features-and-settings.md
+++ b/docs/features-and-settings.md
@@ -123,9 +123,10 @@ Remount logic runs on a 1s interval so SPA navigations between chats still get t
 UI: [`DeleteAllChatsButton`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx).
 
 1. User confirms (Yes / No).
-2. Active tab URL must look like `chatgpt.com` (string slice check on `tabs[0].url`).
-3. Message `{ action: "deleteMessages" }` → content script → [`deleteAllChats()`](../src/lib/utilities/deleteAllChats.ts).
-4. Automation opens profile menu → Settings → delete-all → confirm (selector-dependent).
+2. Active tab hostname must be `chatgpt.com` (or a subdomain).
+3. Message `{ action: "deleteMessages" }` → content script → async [`deleteAllChats()`](../src/lib/utilities/deleteAllChats.ts).
+4. Content script waits (with timeout) for each ChatGPT UI step, then responds SUCCESS/FAILURE.
+5. Popup shows that result — it does **not** claim success just because the message was sent.
 
 Treat this feature as **fragile**; selector failures are expected after ChatGPT UI updates. See [dom-integration.md](dom-integration.md).
 

--- a/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
+++ b/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
@@ -1,47 +1,92 @@
 import React, { useState } from "react";
 import css from "./styles.module.css";
 
+const isChatGptUrl = (url: string | undefined): boolean => {
+    if (!url) return false;
+    try {
+        const { hostname } = new URL(url);
+        return hostname === "chatgpt.com" || hostname.endsWith(".chatgpt.com");
+    } catch {
+        return false;
+    }
+};
+
+type DeleteMessagesResponse = {
+    status?: "SUCCESS" | "FAILURE";
+    message?: string;
+};
+
 export function DeleteAllChatsButton(): JSX.Element {
     const [showConfirmButtons, setShowConfirmButtons] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccessful] = useState<string | null>(null);
+
     const handleClick = (): void => {
         setError(null);
+        setSuccessful(null);
         setShowConfirmButtons(!showConfirmButtons);
     };
 
+    const finishWithMessage = (
+        nextError: string | null,
+        nextSuccess: string | null,
+    ): void => {
+        setError(nextError);
+        setSuccessful(nextSuccess);
+        setIsLoading(false);
+        setShowConfirmButtons(false);
+        window.setTimeout(() => {
+            setError(null);
+            setSuccessful(null);
+        }, 5000);
+    };
+
     /**
-     * Checks if active tab is ChatGPT.
-     * If so, we attempt to delete all messages.
-     * If active tab is not ChatGPT or there is no message history, show an error to the user.
+     * Checks if active tab is ChatGPT, then asks the content script to run
+     * delete-all. Success/failure UI follows the content-script response.
      */
-    const deleteAllChats = (): void => {
+    const requestDeleteAllChats = (): void => {
         console.log("Sending Message to Content Script: Deleting All Messages");
 
         setIsLoading(true);
+        setError(null);
+        setSuccessful(null);
+
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-            if (tabs[0].url?.slice(8, 19) === "chatgpt.com") {
-                chrome.tabs.sendMessage(
-                    tabs[0].id || 0,
-                    { action: "deleteMessages" },
-                    (response) => {
-                        console.log("Response from content script:", response);
-                    },
-                );
-                setSuccessful("All chats have been deleted!");
-                setTimeout(() => {
-                    setError(null);
-                }, 5000);
-            } else {
-                console.error("Active tab is not ChatGPT");
-                setError("Active tab is not ChatGPT");
-                setSuccessful(null);
+            const tab = tabs[0];
+            if (!tab?.id || !isChatGptUrl(tab.url)) {
+                finishWithMessage("Active tab is not ChatGPT", null);
+                return;
             }
-            setIsLoading(false);
-            setShowConfirmButtons(false);
+
+            chrome.tabs.sendMessage(
+                tab.id,
+                { action: "deleteMessages" },
+                (response: DeleteMessagesResponse | undefined) => {
+                    if (chrome.runtime.lastError) {
+                        finishWithMessage(
+                            chrome.runtime.lastError.message ||
+                                "Failed to reach the ChatGPT tab",
+                            null,
+                        );
+                        return;
+                    }
+
+                    if (response?.status === "SUCCESS") {
+                        finishWithMessage(null, "All chats have been deleted!");
+                        return;
+                    }
+
+                    finishWithMessage(
+                        response?.message || "Failed to delete chats",
+                        null,
+                    );
+                },
+            );
         });
     };
+
     return (
         <div>
             <button
@@ -71,7 +116,7 @@ export function DeleteAllChatsButton(): JSX.Element {
                     <button
                         className={css.yesBtn}
                         disabled={isLoading}
-                        onClick={deleteAllChats}
+                        onClick={requestDeleteAllChats}
                     >
                         Yes
                     </button>

--- a/src/components/deleteAllChatsButton/__test__/deleteAllChatsButton.test.tsx
+++ b/src/components/deleteAllChatsButton/__test__/deleteAllChatsButton.test.tsx
@@ -11,8 +11,17 @@ const findButtonByText = (
         .find((button) => button.children.includes(text)) as ReactTestInstance;
 };
 
+const hasHeadingText = (instance: ReactTestInstance, text: string): boolean => {
+    return instance
+        .findAllByType("h1")
+        .some((node) => node.children.includes(text));
+};
+
 describe("DeleteAllChatsButton", () => {
     beforeEach(() => {
+        jest.useFakeTimers();
+        (chrome.runtime as { lastError?: chrome.runtime.LastError }).lastError =
+            undefined;
         (chrome.tabs.query as jest.Mock).mockImplementation(
             (
                 _queryInfo: chrome.tabs.QueryInfo,
@@ -21,6 +30,25 @@ describe("DeleteAllChatsButton", () => {
                 callback([{ id: 1, url: "https://chatgpt.com/" }]);
             },
         );
+        (chrome.tabs.sendMessage as jest.Mock).mockImplementation(
+            (
+                _tabId: number,
+                _message: unknown,
+                callback?: (response: {
+                    status: "SUCCESS" | "FAILURE";
+                    message?: string;
+                }) => void,
+            ) => {
+                if (callback) callback({ status: "SUCCESS" });
+            },
+        );
+    });
+
+    afterEach(() => {
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+        jest.useRealTimers();
     });
 
     it("should render the initial button", () => {
@@ -57,27 +85,91 @@ describe("DeleteAllChatsButton", () => {
         }).toThrow();
     });
 
-    it("should call deleteAllChats when 'Yes' is clicked", () => {
+    it("should show success only after the content script responds", () => {
         const component = renderer.create(<DeleteAllChatsButton />);
         const instance = component.root;
 
-        const deleteButton = findButtonByText(
-            instance,
-            "Delete All Conversations",
-        );
         act(() => {
-            deleteButton.props.onClick();
+            findButtonByText(
+                instance,
+                "Delete All Conversations",
+            ).props.onClick();
         });
-
-        const yesButton = findButtonByText(instance, "Yes");
         act(() => {
-            yesButton.props.onClick();
+            findButtonByText(instance, "Yes").props.onClick();
         });
 
         expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
             1,
             { action: "deleteMessages" },
             expect.any(Function),
+        );
+        expect(hasHeadingText(instance, "All chats have been deleted!")).toBe(
+            true,
+        );
+    });
+
+    it("should show the failure message from the content script", () => {
+        (chrome.tabs.sendMessage as jest.Mock).mockImplementation(
+            (
+                _tabId: number,
+                _message: unknown,
+                callback?: (response: {
+                    status: "SUCCESS" | "FAILURE";
+                    message?: string;
+                }) => void,
+            ) => {
+                if (callback) {
+                    callback({
+                        status: "FAILURE",
+                        message: "No chat history found",
+                    });
+                }
+            },
+        );
+
+        const component = renderer.create(<DeleteAllChatsButton />);
+        const instance = component.root;
+
+        act(() => {
+            findButtonByText(
+                instance,
+                "Delete All Conversations",
+            ).props.onClick();
+        });
+        act(() => {
+            findButtonByText(instance, "Yes").props.onClick();
+        });
+
+        expect(hasHeadingText(instance, "No chat history found")).toBe(true);
+    });
+
+    it("should reject non-ChatGPT tabs", () => {
+        (chrome.tabs.query as jest.Mock).mockImplementation(
+            (
+                _queryInfo: chrome.tabs.QueryInfo,
+                callback: (tabs: Array<{ id: number; url: string }>) => void,
+            ) => {
+                callback([{ id: 1, url: "https://example.com/" }]);
+            },
+        );
+
+        const component = renderer.create(<DeleteAllChatsButton />);
+        const instance = component.root;
+
+        act(() => {
+            findButtonByText(
+                instance,
+                "Delete All Conversations",
+            ).props.onClick();
+        });
+        act(() => {
+            findButtonByText(instance, "Yes").props.onClick();
+        });
+
+        expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+        expect(hasHeadingText(instance, "Active tab is not ChatGPT")).toBe(
+            true,
         );
     });
 

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -24,16 +24,29 @@ getOptionsFromStorage(
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "updateStyles") {
         customStyle.textContent = request.arg;
-    } else if (request.action === "deleteMessages") {
-        console.log("Received Message From Popup: Deleting All Messages");
-        const deleteChats = deleteAllChats();
-        if (deleteChats && deleteChats.message === "No chat history found") {
-            sendResponse({ status: "FAILURE", message: deleteChats.message });
-        } else {
-            sendResponse({ status: "SUCCESS" });
-        }
+        return false;
     }
-    return true;
+
+    if (request.action === "deleteMessages") {
+        console.log("Received Message From Popup: Deleting All Messages");
+        deleteAllChats()
+            .then((result) => {
+                sendResponse(result);
+            })
+            .catch((error: unknown) => {
+                sendResponse({
+                    status: "FAILURE",
+                    message:
+                        error instanceof Error
+                            ? error.message
+                            : "Failed to delete chats",
+                });
+            });
+        // Keep the message channel open for the async response.
+        return true;
+    }
+
+    return false;
 });
 
 const syncLayoutHelpers = (): void => {

--- a/src/lib/utilities/__tests__/deleteAllChats.test.ts
+++ b/src/lib/utilities/__tests__/deleteAllChats.test.ts
@@ -1,0 +1,87 @@
+import { deleteAllChats } from "../deleteAllChats";
+
+const setHtml = (html: string): void => {
+    document.body.innerHTML = html;
+};
+
+describe("deleteAllChats", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        document.body.innerHTML = "";
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it("fails when chat history is missing", async () => {
+        setHtml(`<button aria-label="Open Profile Menu"></button>`);
+
+        await expect(deleteAllChats()).resolves.toEqual({
+            status: "FAILURE",
+            message: "No chat history found",
+        });
+    });
+
+    it("fails when the profile button is missing", async () => {
+        setHtml(`
+            <div class="group/sidebar">
+                <div></div>
+                <div></div>
+                <div><div>chat</div></div>
+            </div>
+        `);
+
+        await expect(deleteAllChats()).resolves.toEqual({
+            status: "FAILURE",
+            message: "Profile button not found!",
+        });
+    });
+
+    it("completes the full delete flow when UI nodes are present", async () => {
+        setHtml(`
+            <div class="group/sidebar">
+                <div></div>
+                <div></div>
+                <div><div>chat</div></div>
+            </div>
+            <button aria-label="Open Profile Menu"></button>
+            <button data-testid="settings-menu-item"></button>
+            <button data-testid="delete-all-chats-button"></button>
+            <button data-testid="confirm-delete-all-chats-button"></button>
+        `);
+
+        const confirm = document.querySelector(
+            '[data-testid="confirm-delete-all-chats-button"]',
+        ) as HTMLButtonElement;
+        const clickSpy = jest.spyOn(confirm, "click");
+
+        await expect(deleteAllChats()).resolves.toEqual({
+            status: "SUCCESS",
+        });
+        expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it("fails with a timeout when a later step never appears", async () => {
+        setHtml(`
+            <div class="group/sidebar">
+                <div></div>
+                <div></div>
+                <div><div>chat</div></div>
+            </div>
+            <button aria-label="Open Profile Menu"></button>
+        `);
+
+        const resultPromise = deleteAllChats();
+        // Allow waitForElement to register its interval, then expire it.
+        await Promise.resolve();
+        jest.advanceTimersByTime(10000);
+        await Promise.resolve();
+
+        await expect(resultPromise).resolves.toEqual({
+            status: "FAILURE",
+            message: expect.stringContaining("Timed out waiting for selector"),
+        });
+    });
+});

--- a/src/lib/utilities/deleteAllChats.ts
+++ b/src/lib/utilities/deleteAllChats.ts
@@ -1,84 +1,134 @@
-export const deleteAllChats = (): Error | void => {
-    try {
-        //querySelector may need to be updated if the domain updates their html
-        const chatHistory = document.querySelector(
-            "div.group\\/sidebar > div:nth-child(3)",
+export type DeleteAllChatsResult =
+    | { status: "SUCCESS" }
+    | { status: "FAILURE"; message: string };
+
+const POLL_INTERVAL_MS = 100;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+const CHAT_HISTORY_SELECTOR = "div.group\\/sidebar > div:nth-child(3)";
+const PROFILE_BUTTON_SELECTOR = '[aria-label="Open Profile Menu"]';
+const SETTINGS_MENU_ITEM_SELECTOR = '[data-testid="settings-menu-item"]';
+const DELETE_ALL_BUTTON_SELECTOR = '[data-testid="delete-all-chats-button"]';
+const CONFIRM_DELETE_BUTTON_SELECTOR =
+    '[data-testid="confirm-delete-all-chats-button"]';
+
+const waitForElement = <T extends Element>(
+    selector: string,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<T> => {
+    return new Promise((resolve, reject) => {
+        const existing = document.querySelector(selector);
+        if (existing) {
+            resolve(existing as T);
+            return;
+        }
+
+        const maxAttempts = Math.max(
+            1,
+            Math.ceil(timeoutMs / POLL_INTERVAL_MS),
         );
+        let attempts = 0;
+        const intervalId = window.setInterval(() => {
+            attempts += 1;
+            const element = document.querySelector(selector);
+            if (element) {
+                window.clearInterval(intervalId);
+                resolve(element as T);
+                return;
+            }
 
-        if (!chatHistory || chatHistory?.children.length === 0)
-            throw new Error("No chat history found");
+            if (attempts >= maxAttempts) {
+                window.clearInterval(intervalId);
+                reject(
+                    new Error(`Timed out waiting for selector: ${selector}`),
+                );
+            }
+        }, POLL_INTERVAL_MS);
+    });
+};
 
-        //querySelector may need to be updated if the domain updates their html
-        const profileButton = document.querySelector(
-            '[aria-label="Open Profile Menu"]',
-        ) as HTMLButtonElement;
+const openProfileMenu = (profileButton: HTMLElement): void => {
+    // pointerdown/up are required for ChatGPT's profile menu in the browser.
+    // Fall back to mouse events in test environments without PointerEvent.
+    const eventInit: MouseEventInit = {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        button: 0,
+    };
 
-        if (!profileButton) throw new Error("Profile button not found!");
-
-        // pointerdown and pointerup events needs to be manually set. click() and mouseclick events for certain elements
+    if (typeof PointerEvent !== "undefined") {
         profileButton.dispatchEvent(
             new PointerEvent("pointerdown", {
-                bubbles: true,
-                cancelable: true,
-                view: window,
-                button: 0,
+                ...eventInit,
                 pointerType: "mouse",
             }),
         );
-
         profileButton.dispatchEvent(
             new PointerEvent("pointerup", {
+                ...eventInit,
+                pointerType: "mouse",
+            }),
+        );
+        return;
+    }
+
+    profileButton.dispatchEvent(new MouseEvent("mousedown", eventInit));
+    profileButton.dispatchEvent(new MouseEvent("mouseup", eventInit));
+    profileButton.dispatchEvent(new MouseEvent("click", eventInit));
+};
+
+/**
+ * Drives ChatGPT's native delete-all UI. Resolves only after the confirm click,
+ * or with FAILURE when a step is missing / times out. Intervals are always cleared.
+ */
+export const deleteAllChats = async (): Promise<DeleteAllChatsResult> => {
+    try {
+        const chatHistory = document.querySelector(CHAT_HISTORY_SELECTOR);
+        if (!chatHistory || chatHistory.children.length === 0) {
+            return { status: "FAILURE", message: "No chat history found" };
+        }
+
+        const profileButton = document.querySelector(
+            PROFILE_BUTTON_SELECTOR,
+        ) as HTMLButtonElement | null;
+        if (!profileButton) {
+            return { status: "FAILURE", message: "Profile button not found!" };
+        }
+
+        openProfileMenu(profileButton);
+
+        const settingsMenuItem = await waitForElement<HTMLButtonElement>(
+            SETTINGS_MENU_ITEM_SELECTOR,
+        );
+        settingsMenuItem.click();
+
+        const deleteAllChatsButton = await waitForElement<HTMLButtonElement>(
+            DELETE_ALL_BUTTON_SELECTOR,
+        );
+        deleteAllChatsButton.dispatchEvent(
+            new MouseEvent("click", {
                 bubbles: true,
                 cancelable: true,
                 view: window,
                 button: 0,
-                pointerType: "mouse",
             }),
         );
 
-        //querySelector may need to be updated if the domain updates their html
-        const settingsMenuItem = document.querySelector(
-            '[data-testid="settings-menu-item"]',
-        ) as HTMLButtonElement;
+        const confirmDeleteButton = await waitForElement<HTMLButtonElement>(
+            CONFIRM_DELETE_BUTTON_SELECTOR,
+        );
+        confirmDeleteButton.click();
 
-        if (!settingsMenuItem) throw new Error("Settings menu item not found!");
-
-        settingsMenuItem.click();
-
-        const checkDeleteAllChatsButton = setInterval(() => {
-            //querySelector may need to be updated if the domain updates their html
-            const deleteAllChatsButton = document.querySelector(
-                '[data-testid="delete-all-chats-button"]',
-            ) as HTMLButtonElement;
-            if (deleteAllChatsButton) {
-                deleteAllChatsButton.dispatchEvent(
-                    new MouseEvent("click", {
-                        bubbles: true,
-                        cancelable: true,
-                        view: window,
-                        button: 0,
-                    }),
-                );
-                clearInterval(checkDeleteAllChatsButton);
-            } else {
-                throw new Error("Delete all chats button not found!");
-            }
-        }, 100);
-
-        const checkConfirmDeleteButton = setInterval(() => {
-            //querySelector may need to be updated if the domain updates their html
-            const confirmDeleteButton = document.querySelector(
-                '[data-testid="confirm-delete-all-chats-button"]',
-            ) as HTMLButtonElement;
-            if (confirmDeleteButton) {
-                confirmDeleteButton.click();
-                clearInterval(checkConfirmDeleteButton);
-            } else {
-                throw new Error("Confirm delete button not found!");
-            }
-        }, 100);
+        return { status: "SUCCESS" };
     } catch (error) {
         console.error(error);
-        return error as Error;
+        return {
+            status: "FAILURE",
+            message:
+                error instanceof Error
+                    ? error.message
+                    : String(error) || "Failed to delete chats",
+        };
     }
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -42,6 +42,7 @@ const chromeMock = {
             },
         })),
         sendMessage: jest.fn(),
+        lastError: undefined as chrome.runtime.LastError | undefined,
     },
 };
 


### PR DESCRIPTION
- Make deleteAllChats async with bounded waits and cleaned-up timers instead of fire-and-forget intervals that throw forever
- Have the content script report SUCCESS only after the confirm click, and FAILURE with a real message otherwise
- Have the popup await that response and surface it (no more instant fake “All chats have been deleted!”)
- Gate on a hostname-based ChatGPT tab check, plus tabs[0] / lastError guards
- Add unit coverage and update architecture/DOM docs; changelog under 1.2.4

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
