### PR TITLE
Improve Popup a11y and Stop Logging Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 -   Renamed popup views to named files (`Popup`, `MessageEditor`, `ColorControls`, `MessageSliderControls`)
 -   Renamed `colorControl` → `colorControls` and `scrollToTop.tsx` → `ScrollToTop.tsx`
 -   Standardized test folders on `__tests__`; removed unused MessageEditor CSS and Tailwind tokens
+-   Improved popup control labeling and delete-all status announcements for assistive tech
+-   Stopped logging user settings and other noisy console messages in production paths
 
 ## [1.2.3] - 2025-06-25
 

--- a/src/backgroundPage.ts
+++ b/src/backgroundPage.ts
@@ -21,17 +21,12 @@ chrome.runtime.onConnect.addListener((port) => {
 
     port.onMessage.addListener((message: PopupPortMessage) => {
         if (message.type === "updateSettings") {
-            console.log(
-                "Received updated settings from popup:",
-                message.settings,
-            );
             currentSettings = message.settings;
             receivedFromPopup = true;
         }
     });
 
     port.onDisconnect.addListener(() => {
-        console.log("Popup closed. Settings are now:", currentSettings);
         // Intentional autosave-on-close. Skip only if we never learned any settings.
         if (currentSettings !== null) {
             saveOptionsToStorage(currentSettings);

--- a/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
+++ b/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
@@ -46,8 +46,6 @@ export function DeleteAllChatsButton(): JSX.Element {
      * delete-all. Success/failure UI follows the content-script response.
      */
     const requestDeleteAllChats = (): void => {
-        console.log("Sending Message to Content Script: Deleting All Messages");
-
         setIsLoading(true);
         setError(null);
         setSuccessful(null);
@@ -93,45 +91,61 @@ export function DeleteAllChatsButton(): JSX.Element {
     return (
         <div>
             <button
+                type="button"
                 className={showConfirmButtons ? "hidden" : css.bigRedBtn}
                 disabled={isLoading || !!error || !!success}
                 onClick={handleClick}
+                aria-expanded={showConfirmButtons}
+                aria-controls="delete-all-confirm"
             >
                 Delete All Conversations
             </button>
             {(error || success) && (
-                <h1
+                <p
+                    role="status"
+                    aria-live="polite"
                     className={
                         (error && css.errorMsg) || (success && css.successMsg)
                     }
                 >
                     {error || success}
-                </h1>
+                </p>
             )}
             <div
+                id="delete-all-confirm"
                 className={
                     showConfirmButtons
                         ? "grid place-items-center gap-2"
                         : "hidden"
                 }
+                role={showConfirmButtons ? "group" : undefined}
+                aria-labelledby={
+                    showConfirmButtons ? "delete-all-confirm-label" : undefined
+                }
             >
                 <div className="w-full grid grid-cols-2 gap-2">
                     <button
+                        type="button"
                         className={css.yesBtn}
                         disabled={isLoading}
                         onClick={requestDeleteAllChats}
+                        aria-describedby="delete-all-confirm-label"
                     >
                         Yes
                     </button>
                     <button
+                        type="button"
                         className={css.noBtn}
                         disabled={isLoading}
                         onClick={handleClick}
+                        aria-describedby="delete-all-confirm-label"
                     >
                         No
                     </button>
                 </div>
-                <h1 className="text-base">Are you sure?</h1>
+                <p id="delete-all-confirm-label" className="text-base">
+                    Are you sure?
+                </p>
             </div>
         </div>
     );

--- a/src/components/deleteAllChatsButton/__tests__/__snapshots__/deleteAllChatsButton.test.tsx.snap
+++ b/src/components/deleteAllChatsButton/__tests__/__snapshots__/deleteAllChatsButton.test.tsx.snap
@@ -3,38 +3,47 @@
 exports[`DeleteAllChatsButton should render the initial button 1`] = `
 <div>
   <button
+    aria-controls="delete-all-confirm"
+    aria-expanded={false}
     className="bigRedBtn"
     disabled={false}
     onClick={[Function]}
+    type="button"
   >
     Delete All Conversations
   </button>
   <div
     className="hidden"
+    id="delete-all-confirm"
   >
     <div
       className="w-full grid grid-cols-2 gap-2"
     >
       <button
+        aria-describedby="delete-all-confirm-label"
         className="yesBtn"
         disabled={false}
         onClick={[Function]}
+        type="button"
       >
         Yes
       </button>
       <button
+        aria-describedby="delete-all-confirm-label"
         className="noBtn"
         disabled={false}
         onClick={[Function]}
+        type="button"
       >
         No
       </button>
     </div>
-    <h1
+    <p
       className="text-base"
+      id="delete-all-confirm-label"
     >
       Are you sure?
-    </h1>
+    </p>
   </div>
 </div>
 `;

--- a/src/components/deleteAllChatsButton/__tests__/deleteAllChatsButton.test.tsx
+++ b/src/components/deleteAllChatsButton/__tests__/deleteAllChatsButton.test.tsx
@@ -11,10 +11,13 @@ const findButtonByText = (
         .find((button) => button.children.includes(text)) as ReactTestInstance;
 };
 
-const hasHeadingText = (instance: ReactTestInstance, text: string): boolean => {
+const hasStatusText = (instance: ReactTestInstance, text: string): boolean => {
     return instance
-        .findAllByType("h1")
-        .some((node) => node.children.includes(text));
+        .findAllByType("p")
+        .some(
+            (node) =>
+                node.props.role === "status" && node.children.includes(text),
+        );
 };
 
 describe("DeleteAllChatsButton", () => {
@@ -104,7 +107,7 @@ describe("DeleteAllChatsButton", () => {
             { action: "deleteMessages" },
             expect.any(Function),
         );
-        expect(hasHeadingText(instance, "All chats have been deleted!")).toBe(
+        expect(hasStatusText(instance, "All chats have been deleted!")).toBe(
             true,
         );
     });
@@ -141,7 +144,7 @@ describe("DeleteAllChatsButton", () => {
             findButtonByText(instance, "Yes").props.onClick();
         });
 
-        expect(hasHeadingText(instance, "No chat history found")).toBe(true);
+        expect(hasStatusText(instance, "No chat history found")).toBe(true);
     });
 
     it("should reject non-ChatGPT tabs", () => {
@@ -168,9 +171,7 @@ describe("DeleteAllChatsButton", () => {
         });
 
         expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
-        expect(hasHeadingText(instance, "Active tab is not ChatGPT")).toBe(
-            true,
-        );
+        expect(hasStatusText(instance, "Active tab is not ChatGPT")).toBe(true);
     });
 
     it("should close the confirmation when 'No' is clicked", () => {

--- a/src/components/formButtons/FormButtons.tsx
+++ b/src/components/formButtons/FormButtons.tsx
@@ -22,8 +22,13 @@ export function FormButtons({
     setSavedSettings,
 }: FormButtonsProps): JSX.Element {
     return (
-        <div className="grid grid-cols-4 gap-1">
+        <div
+            className="grid grid-cols-4 gap-1"
+            role="group"
+            aria-label="Settings actions"
+        >
             <button
+                type="button"
                 className={`${css.btnGrey} col-span-2`}
                 onClick={() => {
                     const nextSettings = { ...defaultSettings };
@@ -35,6 +40,7 @@ export function FormButtons({
                 Restore Defaults
             </button>
             <button
+                type="button"
                 disabled={!isEditing}
                 className={`${css.btn}`}
                 onClick={() => {
@@ -46,6 +52,7 @@ export function FormButtons({
                 Save
             </button>
             <button
+                type="button"
                 disabled={!isEditing}
                 className={`${css.btnRed}`}
                 onClick={() => {

--- a/src/components/formButtons/__tests__/__snapshots__/formButtons.test.tsx.snap
+++ b/src/components/formButtons/__tests__/__snapshots__/formButtons.test.tsx.snap
@@ -2,11 +2,14 @@
 
 exports[`FormButtons renders correctly 1`] = `
 <div
+  aria-label="Settings actions"
   className="grid grid-cols-4 gap-1"
+  role="group"
 >
   <button
     className="btnGrey col-span-2"
     onClick={[Function]}
+    type="button"
   >
     Restore Defaults
   </button>
@@ -14,6 +17,7 @@ exports[`FormButtons renders correctly 1`] = `
     className="btn"
     disabled={true}
     onClick={[Function]}
+    type="button"
   >
     Save
   </button>
@@ -21,6 +25,7 @@ exports[`FormButtons renders correctly 1`] = `
     className="btnRed"
     disabled={true}
     onClick={[Function]}
+    type="button"
   >
     Cancel
   </button>

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -12,8 +12,6 @@ import {
 } from "@src/lib/utilities/chatDom";
 import { ContentScriptMessage } from "@src/shared/messaging";
 
-console.log("Content script loaded.");
-
 const customStyle = document.createElement("style");
 customStyle.id = "custom-style";
 document.head.appendChild(customStyle);
@@ -30,7 +28,6 @@ chrome.runtime.onMessage.addListener(
         }
 
         if (request.action === "deleteMessages") {
-            console.log("Received Message From Popup: Deleting All Messages");
             deleteAllChats()
                 .then((result) => {
                     sendResponse(result);

--- a/src/lib/utilities/settingsStorage.ts
+++ b/src/lib/utilities/settingsStorage.ts
@@ -9,11 +9,9 @@ export const getOptionsFromStorage = (
             ...(result.options || {}),
         };
         callback(options);
-        console.log("GETTING OPTIONS FROM STORAGE", options);
     });
 };
 
 export const saveOptionsToStorage = (options: Settings): void => {
-    console.log("SAVING OPTIONS TO STORAGE", options);
     chrome.storage.sync.set({ options });
 };

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -27,7 +27,6 @@ export function Popup(): JSX.Element {
         };
 
         try {
-            console.log("sending settings to background", updatedSettings);
             port.postMessage(message);
         } catch (error) {
             console.error(error);
@@ -48,7 +47,6 @@ export function Popup(): JSX.Element {
         getOptionsFromStorage((savedOptions) => {
             setLiveSettings(savedOptions);
             setSettingsLoaded(true);
-            console.log("loaded options from storage", savedOptions);
         });
 
         return () => {

--- a/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
+++ b/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
@@ -46,6 +46,7 @@ exports[`component renders 1`] = `
             <input
               className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
               id="messageMaxWidthStyle"
+              inputMode="numeric"
               maxLength={3}
               onChange={[Function]}
               style={
@@ -57,7 +58,9 @@ exports[`component renders 1`] = `
               value="95"
             />
             <input
+              aria-label="Message Width slider"
               className="absolute w-full h-0.5 left-0 bottom-0"
+              id="messageMaxWidthStyle-range"
               max="100"
               min="1"
               onChange={[Function]}
@@ -72,6 +75,7 @@ exports[`component renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
             className="py-2 rounded-r-sm"
             style={
               Object {
@@ -103,6 +107,7 @@ exports[`component renders 1`] = `
             <input
               className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
               id="messagePaddingStyle"
+              inputMode="numeric"
               maxLength={3}
               onChange={[Function]}
               style={
@@ -114,7 +119,9 @@ exports[`component renders 1`] = `
               value="10"
             />
             <input
+              aria-label="Message Padding slider"
               className="absolute w-full h-0.5 left-0 bottom-0"
+              id="messagePaddingStyle-range"
               max="100"
               min="1"
               onChange={[Function]}
@@ -129,6 +136,7 @@ exports[`component renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
             className="py-2 rounded-r-sm"
             style={
               Object {
@@ -160,6 +168,7 @@ exports[`component renders 1`] = `
             <input
               className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
               id="messageBorderRadiusStyle"
+              inputMode="numeric"
               maxLength={3}
               onChange={[Function]}
               style={
@@ -171,7 +180,9 @@ exports[`component renders 1`] = `
               value="5"
             />
             <input
+              aria-label="Message Border slider"
               className="absolute w-full h-0.5 left-0 bottom-0"
+              id="messageBorderRadiusStyle-range"
               max="100"
               min="1"
               onChange={[Function]}
@@ -186,6 +197,7 @@ exports[`component renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
             className="py-2 rounded-r-sm"
             style={
               Object {
@@ -217,6 +229,7 @@ exports[`component renders 1`] = `
             <input
               className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
               id="inputBoxMaxWidthStyle"
+              inputMode="numeric"
               maxLength={3}
               onChange={[Function]}
               style={
@@ -228,7 +241,9 @@ exports[`component renders 1`] = `
               value="94"
             />
             <input
+              aria-label="Input Box Width slider"
               className="absolute w-full h-0.5 left-0 bottom-0"
+              id="inputBoxMaxWidthStyle-range"
               max="100"
               min="1"
               onChange={[Function]}
@@ -243,6 +258,7 @@ exports[`component renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
             className="py-2 rounded-r-sm"
             style={
               Object {
@@ -257,11 +273,12 @@ exports[`component renders 1`] = `
       <div
         className="grid grid-cols-2 gap-2 place-items-center w-full"
       >
-        <div
-          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+        <fieldset
+          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
         >
-          <span
+          <legend
             className=" text-center p-1 w-24 rounded-md"
+            id="user-color-legend"
             style={
               Object {
                 "backgroundColor": "#0084FF",
@@ -270,41 +287,56 @@ exports[`component renders 1`] = `
             }
           >
             User Color
-          </span>
+          </legend>
           <div
+            aria-labelledby="user-color-legend"
             className="grid grid-cols-2 gap-1 w-full text-white"
+            role="group"
           >
-            <input
-              className="text-center w-full rounded-md h-8"
-              id="messageColorUserStyle"
-              onChange={[Function]}
-              type="color"
-              value="#0084FF"
-            />
-            <input
-              className="text-center w-full rounded-md h-8"
-              id="textColorUserStyle"
-              onChange={[Function]}
-              type="color"
-              value="#FFFFFF"
-            />
-            <span
-              className="rounded-md font-medium text-center p-0 m-0"
+            <div
+              className="flex flex-col gap-1 w-full"
             >
-              BG
-            </span>
-            <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              <label
+                className="rounded-md font-medium text-center p-0 m-0"
+                htmlFor="messageColorUserStyle"
+              >
+                BG
+              </label>
+              <input
+                aria-label="User background color"
+                className="text-center w-full rounded-md h-8"
+                id="messageColorUserStyle"
+                onChange={[Function]}
+                type="color"
+                value="#0084FF"
+              />
+            </div>
+            <div
+              className="flex flex-col gap-1 w-full"
             >
-              Text
-            </span>
+              <label
+                className="rounded-md font-medium text-center p-0 m-0"
+                htmlFor="textColorUserStyle"
+              >
+                Text
+              </label>
+              <input
+                aria-label="User text color"
+                className="text-center w-full rounded-md h-8"
+                id="textColorUserStyle"
+                onChange={[Function]}
+                type="color"
+                value="#FFFFFF"
+              />
+            </div>
           </div>
-        </div>
-        <div
-          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+        </fieldset>
+        <fieldset
+          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
         >
-          <span
+          <legend
             className=" text-center p-1 w-24 rounded-md"
+            id="chatgpt-color-legend"
             style={
               Object {
                 "backgroundColor": "#333333",
@@ -313,43 +345,60 @@ exports[`component renders 1`] = `
             }
           >
             ChatGPT Color
-          </span>
+          </legend>
           <div
+            aria-labelledby="chatgpt-color-legend"
             className="grid grid-cols-2 gap-1 w-full text-white"
+            role="group"
           >
-            <input
-              className="text-center w-full rounded-md h-8"
-              id="messageColorNonUserStyle"
-              onChange={[Function]}
-              type="color"
-              value="#333333"
-            />
-            <input
-              className="text-center w-full rounded-md h-8"
-              id="textColorNonUserStyle"
-              onChange={[Function]}
-              type="color"
-              value="#FFFFFF"
-            />
-            <span
-              className="rounded-md font-medium text-center p-0 m-0"
+            <div
+              className="flex flex-col gap-1 w-full"
             >
-              BG
-            </span>
-            <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              <label
+                className="rounded-md font-medium text-center p-0 m-0"
+                htmlFor="messageColorNonUserStyle"
+              >
+                BG
+              </label>
+              <input
+                aria-label="ChatGPT background color"
+                className="text-center w-full rounded-md h-8"
+                id="messageColorNonUserStyle"
+                onChange={[Function]}
+                type="color"
+                value="#333333"
+              />
+            </div>
+            <div
+              className="flex flex-col gap-1 w-full"
             >
-              Text
-            </span>
+              <label
+                className="rounded-md font-medium text-center p-0 m-0"
+                htmlFor="textColorNonUserStyle"
+              >
+                Text
+              </label>
+              <input
+                aria-label="ChatGPT text color"
+                className="text-center w-full rounded-md h-8"
+                id="textColorNonUserStyle"
+                onChange={[Function]}
+                type="color"
+                value="#FFFFFF"
+              />
+            </div>
           </div>
-        </div>
+        </fieldset>
       </div>
       <div
+        aria-label="Settings actions"
         className="grid grid-cols-4 gap-1"
+        role="group"
       >
         <button
           className="btnGrey col-span-2"
           onClick={[Function]}
+          type="button"
         >
           Restore Defaults
         </button>
@@ -357,6 +406,7 @@ exports[`component renders 1`] = `
           className="btn"
           disabled={true}
           onClick={[Function]}
+          type="button"
         >
           Save
         </button>
@@ -364,44 +414,54 @@ exports[`component renders 1`] = `
           className="btnRed"
           disabled={true}
           onClick={[Function]}
+          type="button"
         >
           Cancel
         </button>
       </div>
       <div>
         <button
+          aria-controls="delete-all-confirm"
+          aria-expanded={false}
           className="bigRedBtn"
           disabled={false}
           onClick={[Function]}
+          type="button"
         >
           Delete All Conversations
         </button>
         <div
           className="hidden"
+          id="delete-all-confirm"
         >
           <div
             className="w-full grid grid-cols-2 gap-2"
           >
             <button
+              aria-describedby="delete-all-confirm-label"
               className="yesBtn"
               disabled={false}
               onClick={[Function]}
+              type="button"
             >
               Yes
             </button>
             <button
+              aria-describedby="delete-all-confirm-label"
               className="noBtn"
               disabled={false}
               onClick={[Function]}
+              type="button"
             >
               No
             </button>
           </div>
-          <h1
+          <p
             className="text-base"
+            id="delete-all-confirm-label"
           >
             Are you sure?
-          </h1>
+          </p>
         </div>
       </div>
     </div>

--- a/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
+++ b/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         <input
           className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
           id="messageMaxWidthStyle"
+          inputMode="numeric"
           maxLength={3}
           onChange={[Function]}
           style={
@@ -39,7 +40,9 @@ exports[`MessageEditor Component renders correctly 1`] = `
           value=""
         />
         <input
+          aria-label="Message Width slider"
           className="absolute w-full h-0.5 left-0 bottom-0"
+          id="messageMaxWidthStyle-range"
           max="100"
           min="1"
           onChange={[Function]}
@@ -54,6 +57,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
       </div>
       <div
+        aria-hidden="true"
         className="py-2 rounded-r-sm"
         style={
           Object {
@@ -85,6 +89,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         <input
           className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
           id="messagePaddingStyle"
+          inputMode="numeric"
           maxLength={3}
           onChange={[Function]}
           style={
@@ -96,7 +101,9 @@ exports[`MessageEditor Component renders correctly 1`] = `
           value=""
         />
         <input
+          aria-label="Message Padding slider"
           className="absolute w-full h-0.5 left-0 bottom-0"
+          id="messagePaddingStyle-range"
           max="100"
           min="1"
           onChange={[Function]}
@@ -111,6 +118,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
       </div>
       <div
+        aria-hidden="true"
         className="py-2 rounded-r-sm"
         style={
           Object {
@@ -142,6 +150,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         <input
           className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
           id="messageBorderRadiusStyle"
+          inputMode="numeric"
           maxLength={3}
           onChange={[Function]}
           style={
@@ -153,7 +162,9 @@ exports[`MessageEditor Component renders correctly 1`] = `
           value=""
         />
         <input
+          aria-label="Message Border slider"
           className="absolute w-full h-0.5 left-0 bottom-0"
+          id="messageBorderRadiusStyle-range"
           max="100"
           min="1"
           onChange={[Function]}
@@ -168,6 +179,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
       </div>
       <div
+        aria-hidden="true"
         className="py-2 rounded-r-sm"
         style={
           Object {
@@ -199,6 +211,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         <input
           className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
           id="inputBoxMaxWidthStyle"
+          inputMode="numeric"
           maxLength={3}
           onChange={[Function]}
           style={
@@ -210,7 +223,9 @@ exports[`MessageEditor Component renders correctly 1`] = `
           value=""
         />
         <input
+          aria-label="Input Box Width slider"
           className="absolute w-full h-0.5 left-0 bottom-0"
+          id="inputBoxMaxWidthStyle-range"
           max="100"
           min="1"
           onChange={[Function]}
@@ -225,6 +240,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
       </div>
       <div
+        aria-hidden="true"
         className="py-2 rounded-r-sm"
         style={
           Object {
@@ -239,11 +255,12 @@ exports[`MessageEditor Component renders correctly 1`] = `
   <div
     className="grid grid-cols-2 gap-2 place-items-center w-full"
   >
-    <div
-      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+    <fieldset
+      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
     >
-      <span
+      <legend
         className=" text-center p-1 w-24 rounded-md"
+        id="user-color-legend"
         style={
           Object {
             "backgroundColor": "",
@@ -252,41 +269,56 @@ exports[`MessageEditor Component renders correctly 1`] = `
         }
       >
         User Color
-      </span>
+      </legend>
       <div
+        aria-labelledby="user-color-legend"
         className="grid grid-cols-2 gap-1 w-full text-white"
+        role="group"
       >
-        <input
-          className="text-center w-full rounded-md h-8"
-          id="messageColorUserStyle"
-          onChange={[Function]}
-          type="color"
-          value=""
-        />
-        <input
-          className="text-center w-full rounded-md h-8"
-          id="textColorUserStyle"
-          onChange={[Function]}
-          type="color"
-          value=""
-        />
-        <span
-          className="rounded-md font-medium text-center p-0 m-0"
+        <div
+          className="flex flex-col gap-1 w-full"
         >
-          BG
-        </span>
-        <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          <label
+            className="rounded-md font-medium text-center p-0 m-0"
+            htmlFor="messageColorUserStyle"
+          >
+            BG
+          </label>
+          <input
+            aria-label="User background color"
+            className="text-center w-full rounded-md h-8"
+            id="messageColorUserStyle"
+            onChange={[Function]}
+            type="color"
+            value=""
+          />
+        </div>
+        <div
+          className="flex flex-col gap-1 w-full"
         >
-          Text
-        </span>
+          <label
+            className="rounded-md font-medium text-center p-0 m-0"
+            htmlFor="textColorUserStyle"
+          >
+            Text
+          </label>
+          <input
+            aria-label="User text color"
+            className="text-center w-full rounded-md h-8"
+            id="textColorUserStyle"
+            onChange={[Function]}
+            type="color"
+            value=""
+          />
+        </div>
       </div>
-    </div>
-    <div
-      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+    </fieldset>
+    <fieldset
+      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
     >
-      <span
+      <legend
         className=" text-center p-1 w-24 rounded-md"
+        id="chatgpt-color-legend"
         style={
           Object {
             "backgroundColor": "",
@@ -295,43 +327,60 @@ exports[`MessageEditor Component renders correctly 1`] = `
         }
       >
         ChatGPT Color
-      </span>
+      </legend>
       <div
+        aria-labelledby="chatgpt-color-legend"
         className="grid grid-cols-2 gap-1 w-full text-white"
+        role="group"
       >
-        <input
-          className="text-center w-full rounded-md h-8"
-          id="messageColorNonUserStyle"
-          onChange={[Function]}
-          type="color"
-          value=""
-        />
-        <input
-          className="text-center w-full rounded-md h-8"
-          id="textColorNonUserStyle"
-          onChange={[Function]}
-          type="color"
-          value=""
-        />
-        <span
-          className="rounded-md font-medium text-center p-0 m-0"
+        <div
+          className="flex flex-col gap-1 w-full"
         >
-          BG
-        </span>
-        <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          <label
+            className="rounded-md font-medium text-center p-0 m-0"
+            htmlFor="messageColorNonUserStyle"
+          >
+            BG
+          </label>
+          <input
+            aria-label="ChatGPT background color"
+            className="text-center w-full rounded-md h-8"
+            id="messageColorNonUserStyle"
+            onChange={[Function]}
+            type="color"
+            value=""
+          />
+        </div>
+        <div
+          className="flex flex-col gap-1 w-full"
         >
-          Text
-        </span>
+          <label
+            className="rounded-md font-medium text-center p-0 m-0"
+            htmlFor="textColorNonUserStyle"
+          >
+            Text
+          </label>
+          <input
+            aria-label="ChatGPT text color"
+            className="text-center w-full rounded-md h-8"
+            id="textColorNonUserStyle"
+            onChange={[Function]}
+            type="color"
+            value=""
+          />
+        </div>
       </div>
-    </div>
+    </fieldset>
   </div>
   <div
+    aria-label="Settings actions"
     className="grid grid-cols-4 gap-1"
+    role="group"
   >
     <button
       className="btnGrey col-span-2"
       onClick={[Function]}
+      type="button"
     >
       Restore Defaults
     </button>
@@ -339,6 +388,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
       className="btn"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Save
     </button>
@@ -346,44 +396,54 @@ exports[`MessageEditor Component renders correctly 1`] = `
       className="btnRed"
       disabled={true}
       onClick={[Function]}
+      type="button"
     >
       Cancel
     </button>
   </div>
   <div>
     <button
+      aria-controls="delete-all-confirm"
+      aria-expanded={false}
       className="bigRedBtn"
       disabled={false}
       onClick={[Function]}
+      type="button"
     >
       Delete All Conversations
     </button>
     <div
       className="hidden"
+      id="delete-all-confirm"
     >
       <div
         className="w-full grid grid-cols-2 gap-2"
       >
         <button
+          aria-describedby="delete-all-confirm-label"
           className="yesBtn"
           disabled={false}
           onClick={[Function]}
+          type="button"
         >
           Yes
         </button>
         <button
+          aria-describedby="delete-all-confirm-label"
           className="noBtn"
           disabled={false}
           onClick={[Function]}
+          type="button"
         >
           No
         </button>
       </div>
-      <h1
+      <p
         className="text-base"
+        id="delete-all-confirm-label"
       >
         Are you sure?
-      </h1>
+      </p>
     </div>
   </div>
 </div>

--- a/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
+++ b/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
@@ -19,12 +19,15 @@ export function ColorControls({
 
     const mapColorSettings = (userType: string, index: number) => {
         const isUser = userType === "User";
+        const legendId = `${isUser ? "user" : "chatgpt"}-color-legend`;
+
         return (
-            <div
+            <fieldset
                 key={index}
-                className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+                className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
             >
-                <span
+                <legend
+                    id={legendId}
                     className=" text-center p-1 w-24 rounded-md"
                     style={{
                         backgroundColor:
@@ -45,19 +48,22 @@ export function ColorControls({
                     }}
                 >
                     {`${userType} Color`}
-                </span>
-                <div className="grid grid-cols-2 gap-1 w-full text-white">
-                    {colorSettings.map((setting, index) =>
-                        mapSettingInputs(setting, index, isUser),
+                </legend>
+                <div
+                    className="grid grid-cols-2 gap-1 w-full text-white"
+                    role="group"
+                    aria-labelledby={legendId}
+                >
+                    {colorSettings.map((setting, settingIndex) =>
+                        mapSettingInputs(
+                            setting,
+                            settingIndex,
+                            isUser,
+                            userType,
+                        ),
                     )}
-                    <span className="rounded-md font-medium text-center p-0 m-0">
-                        BG
-                    </span>
-                    <span className="rounded-md font-medium text-center p-0 m-0">
-                        Text
-                    </span>
                 </div>
-            </div>
+            </fieldset>
         );
     };
 
@@ -65,10 +71,13 @@ export function ColorControls({
         setting: ColorSetting,
         index: number,
         isUser: boolean,
+        userType: string,
     ) => {
         const settingsKey: keyof Settings = `${setting}${
             isUser ? "User" : "NonUser"
         }Style`;
+        const channelLabel = setting === "messageColor" ? "background" : "text";
+        const labelText = setting === "messageColor" ? "BG" : "Text";
 
         const handleOnChange = (
             e: React.ChangeEvent<HTMLInputElement>,
@@ -82,15 +91,24 @@ export function ColorControls({
             sendMessageToTab(nextSettings);
             setIsEditing(true);
         };
+
         return (
-            <input
-                key={index}
-                className={`text-center w-full rounded-md h-8`}
-                type="color"
-                id={`${settingsKey}`}
-                value={liveSettings[settingsKey]}
-                onChange={(e) => handleOnChange(e, settingsKey)}
-            />
+            <div key={index} className="flex flex-col gap-1 w-full">
+                <label
+                    htmlFor={settingsKey}
+                    className="rounded-md font-medium text-center p-0 m-0"
+                >
+                    {labelText}
+                </label>
+                <input
+                    className="text-center w-full rounded-md h-8"
+                    type="color"
+                    id={settingsKey}
+                    aria-label={`${userType} ${channelLabel} color`}
+                    value={liveSettings[settingsKey]}
+                    onChange={(e) => handleOnChange(e, settingsKey)}
+                />
+            </div>
         );
     };
 

--- a/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
+++ b/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
@@ -4,11 +4,12 @@ exports[`ColorControls component renders correctly 1`] = `
 <div
   className="grid grid-cols-2 gap-2 place-items-center w-full"
 >
-  <div
-    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+  <fieldset
+    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
   >
-    <span
+    <legend
       className=" text-center p-1 w-24 rounded-md"
+      id="user-color-legend"
       style={
         Object {
           "backgroundColor": "#386d9f",
@@ -17,41 +18,56 @@ exports[`ColorControls component renders correctly 1`] = `
       }
     >
       User Color
-    </span>
+    </legend>
     <div
+      aria-labelledby="user-color-legend"
       className="grid grid-cols-2 gap-1 w-full text-white"
+      role="group"
     >
-      <input
-        className="text-center w-full rounded-md h-8"
-        id="messageColorUserStyle"
-        onChange={[Function]}
-        type="color"
-        value="#386d9f"
-      />
-      <input
-        className="text-center w-full rounded-md h-8"
-        id="textColorUserStyle"
-        onChange={[Function]}
-        type="color"
-        value="#FFFFFF"
-      />
-      <span
-        className="rounded-md font-medium text-center p-0 m-0"
+      <div
+        className="flex flex-col gap-1 w-full"
       >
-        BG
-      </span>
-      <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        <label
+          className="rounded-md font-medium text-center p-0 m-0"
+          htmlFor="messageColorUserStyle"
+        >
+          BG
+        </label>
+        <input
+          aria-label="User background color"
+          className="text-center w-full rounded-md h-8"
+          id="messageColorUserStyle"
+          onChange={[Function]}
+          type="color"
+          value="#386d9f"
+        />
+      </div>
+      <div
+        className="flex flex-col gap-1 w-full"
       >
-        Text
-      </span>
+        <label
+          className="rounded-md font-medium text-center p-0 m-0"
+          htmlFor="textColorUserStyle"
+        >
+          Text
+        </label>
+        <input
+          aria-label="User text color"
+          className="text-center w-full rounded-md h-8"
+          id="textColorUserStyle"
+          onChange={[Function]}
+          type="color"
+          value="#FFFFFF"
+        />
+      </div>
     </div>
-  </div>
-  <div
-    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full"
+  </fieldset>
+  <fieldset
+    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
   >
-    <span
+    <legend
       className=" text-center p-1 w-24 rounded-md"
+      id="chatgpt-color-legend"
       style={
         Object {
           "backgroundColor": "#333333",
@@ -60,35 +76,49 @@ exports[`ColorControls component renders correctly 1`] = `
       }
     >
       ChatGPT Color
-    </span>
+    </legend>
     <div
+      aria-labelledby="chatgpt-color-legend"
       className="grid grid-cols-2 gap-1 w-full text-white"
+      role="group"
     >
-      <input
-        className="text-center w-full rounded-md h-8"
-        id="messageColorNonUserStyle"
-        onChange={[Function]}
-        type="color"
-        value="#333333"
-      />
-      <input
-        className="text-center w-full rounded-md h-8"
-        id="textColorNonUserStyle"
-        onChange={[Function]}
-        type="color"
-        value="#FFFFFF"
-      />
-      <span
-        className="rounded-md font-medium text-center p-0 m-0"
+      <div
+        className="flex flex-col gap-1 w-full"
       >
-        BG
-      </span>
-      <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        <label
+          className="rounded-md font-medium text-center p-0 m-0"
+          htmlFor="messageColorNonUserStyle"
+        >
+          BG
+        </label>
+        <input
+          aria-label="ChatGPT background color"
+          className="text-center w-full rounded-md h-8"
+          id="messageColorNonUserStyle"
+          onChange={[Function]}
+          type="color"
+          value="#333333"
+        />
+      </div>
+      <div
+        className="flex flex-col gap-1 w-full"
       >
-        Text
-      </span>
+        <label
+          className="rounded-md font-medium text-center p-0 m-0"
+          htmlFor="textColorNonUserStyle"
+        >
+          Text
+        </label>
+        <input
+          aria-label="ChatGPT text color"
+          className="text-center w-full rounded-md h-8"
+          id="textColorNonUserStyle"
+          onChange={[Function]}
+          type="color"
+          value="#FFFFFF"
+        />
+      </div>
     </div>
-  </div>
+  </fieldset>
 </div>
 `;

--- a/src/popup/views/messageEditor/components/messageSliderControls/MessageSliderControls.tsx
+++ b/src/popup/views/messageEditor/components/messageSliderControls/MessageSliderControls.tsx
@@ -55,6 +55,8 @@ export function MessageSliderControls({
     ];
 
     const mapInputSettings = (setting: InputSetting, index: number) => {
+        const rangeId = `${setting.id}-range`;
+
         const handleOnChange = (
             e: React.ChangeEvent<HTMLInputElement>,
             settingKey: keyof Settings,
@@ -86,6 +88,7 @@ export function MessageSliderControls({
                         className={`outline-none px-2 py-2 w-full text-right rounded-l-sm `}
                         type="text"
                         maxLength={3}
+                        inputMode="numeric"
                         style={{
                             backgroundColor: `${setting.bgColor}, 0.1)`,
                         }}
@@ -95,6 +98,7 @@ export function MessageSliderControls({
                     ></input>
                     <input
                         type="range"
+                        id={rangeId}
                         min="1"
                         max="100"
                         value={liveSettings[setting.id].toString()}
@@ -102,6 +106,7 @@ export function MessageSliderControls({
                         onChange={(e) => handleOnChange(e, setting.id)}
                         step={"1"}
                         style={{ accentColor: `${setting.bgColor})` }}
+                        aria-label={`${setting.name} slider`}
                     ></input>
                 </div>
                 <div
@@ -109,6 +114,7 @@ export function MessageSliderControls({
                     style={{
                         backgroundColor: `${setting.bgColor}, 0.1)`,
                     }}
+                    aria-hidden="true"
                 >
                     {setting.valueType}
                 </div>

--- a/src/popup/views/messageEditor/components/messageSliderControls/__tests__/__snapshots__/messageSliderControls.test.tsx.snap
+++ b/src/popup/views/messageEditor/components/messageSliderControls/__tests__/__snapshots__/messageSliderControls.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       <input
         className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
         id="messageMaxWidthStyle"
+        inputMode="numeric"
         maxLength={3}
         onChange={[Function]}
         style={
@@ -36,7 +37,9 @@ exports[`MessageSliderControls component renders correctly 1`] = `
         value="95"
       />
       <input
+        aria-label="Message Width slider"
         className="absolute w-full h-0.5 left-0 bottom-0"
+        id="messageMaxWidthStyle-range"
         max="100"
         min="1"
         onChange={[Function]}
@@ -51,6 +54,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       />
     </div>
     <div
+      aria-hidden="true"
       className="py-2 rounded-r-sm"
       style={
         Object {
@@ -82,6 +86,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       <input
         className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
         id="messagePaddingStyle"
+        inputMode="numeric"
         maxLength={3}
         onChange={[Function]}
         style={
@@ -93,7 +98,9 @@ exports[`MessageSliderControls component renders correctly 1`] = `
         value="10"
       />
       <input
+        aria-label="Message Padding slider"
         className="absolute w-full h-0.5 left-0 bottom-0"
+        id="messagePaddingStyle-range"
         max="100"
         min="1"
         onChange={[Function]}
@@ -108,6 +115,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       />
     </div>
     <div
+      aria-hidden="true"
       className="py-2 rounded-r-sm"
       style={
         Object {
@@ -139,6 +147,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       <input
         className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
         id="messageBorderRadiusStyle"
+        inputMode="numeric"
         maxLength={3}
         onChange={[Function]}
         style={
@@ -150,7 +159,9 @@ exports[`MessageSliderControls component renders correctly 1`] = `
         value="5"
       />
       <input
+        aria-label="Message Border slider"
         className="absolute w-full h-0.5 left-0 bottom-0"
+        id="messageBorderRadiusStyle-range"
         max="100"
         min="1"
         onChange={[Function]}
@@ -165,6 +176,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       />
     </div>
     <div
+      aria-hidden="true"
       className="py-2 rounded-r-sm"
       style={
         Object {
@@ -196,6 +208,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       <input
         className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
         id="inputBoxMaxWidthStyle"
+        inputMode="numeric"
         maxLength={3}
         onChange={[Function]}
         style={
@@ -207,7 +220,9 @@ exports[`MessageSliderControls component renders correctly 1`] = `
         value="94"
       />
       <input
+        aria-label="Input Box Width slider"
         className="absolute w-full h-0.5 left-0 bottom-0"
+        id="inputBoxMaxWidthStyle-range"
         max="100"
         min="1"
         onChange={[Function]}
@@ -222,6 +237,7 @@ exports[`MessageSliderControls component renders correctly 1`] = `
       />
     </div>
     <div
+      aria-hidden="true"
       className="py-2 rounded-r-sm"
       style={
         Object {


### PR DESCRIPTION
- Label color pickers with fieldsets/legends and explicit aria-labels
- Give slider range inputs accessible names; keep text inputs labeled
- Announce delete-all success/failure with role="status" / aria-live
- Add type="button" and clearer confirmation semantics on action buttons
- Remove settings dumps and other noisy production console.logs
- Keep real console.error paths for failures
- Update snapshots and the 1.2.4 changelog

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
