### PR TITLE
Upgrade TypeScript and Fix Popup Button/Color a11y Regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -   Made scroll-to-top remount correctly when ChatGPT replaces its scroll container
 -   Made delete-all report success only after the ChatGPT UI flow completes
 -   Stopped delete-all polling from throwing forever when buttons never appear
+-   Restored the color controls' original visual layout while preserving their accessible names
+-   Restored popup button backgrounds after `type="button"` lost to Tailwind preflight specificity
 
 ### Changed
 
@@ -33,6 +35,7 @@
 -   Standardized test folders on `__tests__`; removed unused MessageEditor CSS and Tailwind tokens
 -   Improved popup control labeling and delete-all status announcements for assistive tech
 -   Stopped logging user settings and other noisy console messages in production paths
+-   Upgraded TypeScript to 4.9.5 and aligned `@types/node` to 24.x; bumped `ts-loader` for compatibility
 
 ## [1.2.3] - 2025-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ npm run lint         # ESLint --fix on src/**/*.ts*
 npm run prettify     # Prettier --write on src/**/*.ts*
 ```
 
-Node / npm: [`.nvmrc`](.nvmrc) → **24.18.0**; `engines` require Node 24.x and npm ≥11. PR CI and release CI read `.nvmrc` and run `npm ci` ([`.github/workflows/ci.yml`](.github/workflows/ci.yml), [`.github/workflows/release-artifacts.yml`](.github/workflows/release-artifacts.yml)). `@types/node` stays on a TypeScript **4.5**-compatible pin until TypeScript itself is upgraded (newer `@types/node` use syntax TS 4.5 cannot parse).
+Node / npm: [`.nvmrc`](.nvmrc) → **24.18.0**; `engines` require Node 24.x and npm ≥11. PR CI and release CI read `.nvmrc` and run `npm ci` ([`.github/workflows/ci.yml`](.github/workflows/ci.yml), [`.github/workflows/release-artifacts.yml`](.github/workflows/release-artifacts.yml)). TypeScript is **4.9.5** with `@types/node` **24.x** (aligned to the runtime Node major).
 
 ## Architecture (short)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ Line endings: [`.gitattributes`](../.gitattributes) and Prettier `endOfLine: "lf
 
 TypeScript config: [`tsconfig.json`](../tsconfig.json) (`strict`, JSX react, path `@src/*`, `skipLibCheck`). ESLint: [`.eslintrc.js`](../.eslintrc.js). Prettier: [`.prettierrc.js`](../.prettierrc.js). Tailwind: [`tailwind.config.js`](../tailwind.config.js) + [`postcss.config.js`](../postcss.config.js). Webpack CSS pipeline uses `style-loader` + `css-loader` + `postcss-loader`.
 
-**Note:** Runtime is Node 24, but `@types/node` remains on a TypeScript 4.5-compatible pin. Bumping `@types/node` to match Node 24 requires upgrading TypeScript first.
+**Note:** Runtime is Node 24 with TypeScript **4.9.5** and `@types/node` **24.x**. A TypeScript 5.x jump can wait for a dedicated PR (and likely pairs with Jest modernization).
 
 ## Loading the unpacked extension
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
             "devDependencies": {
                 "@types/chrome": "0.0.124",
                 "@types/jest": "26.0.24",
-                "@types/node": "14.18.4",
+                "@types/node": "24.13.3",
                 "@types/react": "17.0.75",
                 "@types/react-dom": "17.0.25",
                 "@types/react-test-renderer": "17.0.9",
@@ -36,8 +36,8 @@
                 "style-loader": "3.3.4",
                 "tailwindcss": "3.0.8",
                 "ts-jest": "26.5.6",
-                "ts-loader": "8.3.0",
-                "typescript": "4.5.4",
+                "ts-loader": "9.5.1",
+                "typescript": "4.9.5",
                 "webpack": "5.108.4",
                 "webpack-cli": "4.10.0",
                 "webpack-merge": "5.10.0"
@@ -1457,11 +1457,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "14.18.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.4.tgz",
-            "integrity": "sha512-swe3lD4izOJWHuxvsZdDFRq6S9i6koJsXOnQKYekhSO5JTizMVirUFgY/bUsaOJQj8oSD4oxmRYPBM/0b6jpdw==",
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.18.0"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -2901,12 +2904,6 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -3313,17 +3310,17 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "version": "5.24.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.5.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
             },
             "engines": {
-                "node": ">=6.9.0"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/enquirer": {
@@ -3349,18 +3346,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/errno": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
-            "dependencies": {
-                "prr": "~1.0.1"
-            },
-            "bin": {
-                "errno": "cli.js"
             }
         },
         "node_modules/error-ex": {
@@ -5213,12 +5198,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -7126,43 +7105,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/memory-fs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-            "dev": true,
-            "dependencies": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4.3.0 <5.0.0 || >=5.10"
-            }
-        },
-        "node_modules/memory-fs/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/memory-fs/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8107,12 +8049,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8150,12 +8086,6 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
-        },
-        "node_modules/prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY= sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true
         },
         "node_modules/psl": {
@@ -9426,12 +9356,17 @@
             }
         },
         "node_modules/tapable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terminal-link": {
@@ -9597,23 +9532,24 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.3.0.tgz",
-            "integrity": "sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+            "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^2.0.0",
+                "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12.0.0"
             },
             "peerDependencies": {
                 "typescript": "*",
-                "webpack": "*"
+                "webpack": "^5.0.0"
             }
         },
         "node_modules/ts-loader/node_modules/ansi-styles": {
@@ -9669,6 +9605,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/ts-loader/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/ts-loader/node_modules/supports-color": {
@@ -9813,10 +9759,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9839,6 +9786,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
@@ -10176,20 +10130,6 @@
                 "ajv": "^8.8.2"
             }
         },
-        "node_modules/webpack/node_modules/enhanced-resolve": {
-            "version": "5.24.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/webpack/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10221,20 +10161,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/webpack/node_modules/tapable": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             },
             "funding": {
                 "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "devDependencies": {
         "@types/chrome": "0.0.124",
         "@types/jest": "26.0.24",
-        "@types/node": "14.18.4",
+        "@types/node": "24.13.3",
         "@types/react": "17.0.75",
         "@types/react-dom": "17.0.25",
         "@types/react-test-renderer": "17.0.9",
@@ -62,8 +62,8 @@
         "style-loader": "3.3.4",
         "tailwindcss": "3.0.8",
         "ts-jest": "26.5.6",
-        "ts-loader": "8.3.0",
-        "typescript": "4.5.4",
+        "ts-loader": "9.5.1",
+        "typescript": "4.9.5",
         "webpack": "5.108.4",
         "webpack-cli": "4.10.0",
         "webpack-merge": "5.10.0"

--- a/src/components/deleteAllChatsButton/styles.module.css
+++ b/src/components/deleteAllChatsButton/styles.module.css
@@ -1,4 +1,4 @@
-.bigRedBtn {
+button.bigRedBtn {
     @apply px-4;
     @apply py-2;
     @apply font-medium;
@@ -15,7 +15,7 @@
     @apply disabled:pointer-events-none;
 }
 
-.yesBtn {
+button.yesBtn {
     @apply px-4;
     @apply py-2;
     @apply font-medium;
@@ -30,7 +30,7 @@
     @apply disabled:bg-green-800/50;
 }
 
-.noBtn {
+button.noBtn {
     @apply px-4;
     @apply py-2;
     @apply font-medium;

--- a/src/components/formButtons/styles.module.css
+++ b/src/components/formButtons/styles.module.css
@@ -1,4 +1,4 @@
-.btn {
+button.btn {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;
@@ -23,7 +23,7 @@
     @apply disabled:shadow-none;
     @apply duration-300;
 }
-.btnRed {
+button.btnRed {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;
@@ -49,7 +49,7 @@
     @apply duration-300;
 }
 
-.btnGrey {
+button.btnGrey {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;

--- a/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
+++ b/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
@@ -277,8 +277,13 @@ exports[`component renders 1`] = `
           className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
         >
           <legend
-            className=" text-center p-1 w-24 rounded-md"
-            id="user-color-legend"
+            className="sr-only"
+          >
+            User color settings
+          </legend>
+          <div
+            aria-hidden="true"
+            className="text-center p-1 w-24 rounded-md"
             style={
               Object {
                 "backgroundColor": "#0084FF",
@@ -287,56 +292,49 @@ exports[`component renders 1`] = `
             }
           >
             User Color
-          </legend>
+          </div>
           <div
-            aria-labelledby="user-color-legend"
             className="grid grid-cols-2 gap-1 w-full text-white"
-            role="group"
           >
-            <div
-              className="flex flex-col gap-1 w-full"
+            <input
+              aria-label="User background color"
+              className="text-center w-full rounded-md h-8"
+              id="messageColorUserStyle"
+              onChange={[Function]}
+              type="color"
+              value="#0084FF"
+            />
+            <input
+              aria-label="User text color"
+              className="text-center w-full rounded-md h-8"
+              id="textColorUserStyle"
+              onChange={[Function]}
+              type="color"
+              value="#FFFFFF"
+            />
+            <span
+              className="rounded-md font-medium text-center p-0 m-0"
             >
-              <label
-                className="rounded-md font-medium text-center p-0 m-0"
-                htmlFor="messageColorUserStyle"
-              >
-                BG
-              </label>
-              <input
-                aria-label="User background color"
-                className="text-center w-full rounded-md h-8"
-                id="messageColorUserStyle"
-                onChange={[Function]}
-                type="color"
-                value="#0084FF"
-              />
-            </div>
-            <div
-              className="flex flex-col gap-1 w-full"
+              BG
+            </span>
+            <span
+              className="rounded-md font-medium text-center p-0 m-0"
             >
-              <label
-                className="rounded-md font-medium text-center p-0 m-0"
-                htmlFor="textColorUserStyle"
-              >
-                Text
-              </label>
-              <input
-                aria-label="User text color"
-                className="text-center w-full rounded-md h-8"
-                id="textColorUserStyle"
-                onChange={[Function]}
-                type="color"
-                value="#FFFFFF"
-              />
-            </div>
+              Text
+            </span>
           </div>
         </fieldset>
         <fieldset
           className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
         >
           <legend
-            className=" text-center p-1 w-24 rounded-md"
-            id="chatgpt-color-legend"
+            className="sr-only"
+          >
+            ChatGPT color settings
+          </legend>
+          <div
+            aria-hidden="true"
+            className="text-center p-1 w-24 rounded-md"
             style={
               Object {
                 "backgroundColor": "#333333",
@@ -345,48 +343,36 @@ exports[`component renders 1`] = `
             }
           >
             ChatGPT Color
-          </legend>
+          </div>
           <div
-            aria-labelledby="chatgpt-color-legend"
             className="grid grid-cols-2 gap-1 w-full text-white"
-            role="group"
           >
-            <div
-              className="flex flex-col gap-1 w-full"
+            <input
+              aria-label="ChatGPT background color"
+              className="text-center w-full rounded-md h-8"
+              id="messageColorNonUserStyle"
+              onChange={[Function]}
+              type="color"
+              value="#333333"
+            />
+            <input
+              aria-label="ChatGPT text color"
+              className="text-center w-full rounded-md h-8"
+              id="textColorNonUserStyle"
+              onChange={[Function]}
+              type="color"
+              value="#FFFFFF"
+            />
+            <span
+              className="rounded-md font-medium text-center p-0 m-0"
             >
-              <label
-                className="rounded-md font-medium text-center p-0 m-0"
-                htmlFor="messageColorNonUserStyle"
-              >
-                BG
-              </label>
-              <input
-                aria-label="ChatGPT background color"
-                className="text-center w-full rounded-md h-8"
-                id="messageColorNonUserStyle"
-                onChange={[Function]}
-                type="color"
-                value="#333333"
-              />
-            </div>
-            <div
-              className="flex flex-col gap-1 w-full"
+              BG
+            </span>
+            <span
+              className="rounded-md font-medium text-center p-0 m-0"
             >
-              <label
-                className="rounded-md font-medium text-center p-0 m-0"
-                htmlFor="textColorNonUserStyle"
-              >
-                Text
-              </label>
-              <input
-                aria-label="ChatGPT text color"
-                className="text-center w-full rounded-md h-8"
-                id="textColorNonUserStyle"
-                onChange={[Function]}
-                type="color"
-                value="#FFFFFF"
-              />
-            </div>
+              Text
+            </span>
           </div>
         </fieldset>
       </div>

--- a/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
+++ b/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
@@ -259,8 +259,13 @@ exports[`MessageEditor Component renders correctly 1`] = `
       className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
     >
       <legend
-        className=" text-center p-1 w-24 rounded-md"
-        id="user-color-legend"
+        className="sr-only"
+      >
+        User color settings
+      </legend>
+      <div
+        aria-hidden="true"
+        className="text-center p-1 w-24 rounded-md"
         style={
           Object {
             "backgroundColor": "",
@@ -269,56 +274,49 @@ exports[`MessageEditor Component renders correctly 1`] = `
         }
       >
         User Color
-      </legend>
+      </div>
       <div
-        aria-labelledby="user-color-legend"
         className="grid grid-cols-2 gap-1 w-full text-white"
-        role="group"
       >
-        <div
-          className="flex flex-col gap-1 w-full"
+        <input
+          aria-label="User background color"
+          className="text-center w-full rounded-md h-8"
+          id="messageColorUserStyle"
+          onChange={[Function]}
+          type="color"
+          value=""
+        />
+        <input
+          aria-label="User text color"
+          className="text-center w-full rounded-md h-8"
+          id="textColorUserStyle"
+          onChange={[Function]}
+          type="color"
+          value=""
+        />
+        <span
+          className="rounded-md font-medium text-center p-0 m-0"
         >
-          <label
-            className="rounded-md font-medium text-center p-0 m-0"
-            htmlFor="messageColorUserStyle"
-          >
-            BG
-          </label>
-          <input
-            aria-label="User background color"
-            className="text-center w-full rounded-md h-8"
-            id="messageColorUserStyle"
-            onChange={[Function]}
-            type="color"
-            value=""
-          />
-        </div>
-        <div
-          className="flex flex-col gap-1 w-full"
+          BG
+        </span>
+        <span
+          className="rounded-md font-medium text-center p-0 m-0"
         >
-          <label
-            className="rounded-md font-medium text-center p-0 m-0"
-            htmlFor="textColorUserStyle"
-          >
-            Text
-          </label>
-          <input
-            aria-label="User text color"
-            className="text-center w-full rounded-md h-8"
-            id="textColorUserStyle"
-            onChange={[Function]}
-            type="color"
-            value=""
-          />
-        </div>
+          Text
+        </span>
       </div>
     </fieldset>
     <fieldset
       className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
     >
       <legend
-        className=" text-center p-1 w-24 rounded-md"
-        id="chatgpt-color-legend"
+        className="sr-only"
+      >
+        ChatGPT color settings
+      </legend>
+      <div
+        aria-hidden="true"
+        className="text-center p-1 w-24 rounded-md"
         style={
           Object {
             "backgroundColor": "",
@@ -327,48 +325,36 @@ exports[`MessageEditor Component renders correctly 1`] = `
         }
       >
         ChatGPT Color
-      </legend>
+      </div>
       <div
-        aria-labelledby="chatgpt-color-legend"
         className="grid grid-cols-2 gap-1 w-full text-white"
-        role="group"
       >
-        <div
-          className="flex flex-col gap-1 w-full"
+        <input
+          aria-label="ChatGPT background color"
+          className="text-center w-full rounded-md h-8"
+          id="messageColorNonUserStyle"
+          onChange={[Function]}
+          type="color"
+          value=""
+        />
+        <input
+          aria-label="ChatGPT text color"
+          className="text-center w-full rounded-md h-8"
+          id="textColorNonUserStyle"
+          onChange={[Function]}
+          type="color"
+          value=""
+        />
+        <span
+          className="rounded-md font-medium text-center p-0 m-0"
         >
-          <label
-            className="rounded-md font-medium text-center p-0 m-0"
-            htmlFor="messageColorNonUserStyle"
-          >
-            BG
-          </label>
-          <input
-            aria-label="ChatGPT background color"
-            className="text-center w-full rounded-md h-8"
-            id="messageColorNonUserStyle"
-            onChange={[Function]}
-            type="color"
-            value=""
-          />
-        </div>
-        <div
-          className="flex flex-col gap-1 w-full"
+          BG
+        </span>
+        <span
+          className="rounded-md font-medium text-center p-0 m-0"
         >
-          <label
-            className="rounded-md font-medium text-center p-0 m-0"
-            htmlFor="textColorNonUserStyle"
-          >
-            Text
-          </label>
-          <input
-            aria-label="ChatGPT text color"
-            className="text-center w-full rounded-md h-8"
-            id="textColorNonUserStyle"
-            onChange={[Function]}
-            type="color"
-            value=""
-          />
-        </div>
+          Text
+        </span>
       </div>
     </fieldset>
   </div>

--- a/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
+++ b/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
@@ -19,16 +19,16 @@ export function ColorControls({
 
     const mapColorSettings = (userType: string, index: number) => {
         const isUser = userType === "User";
-        const legendId = `${isUser ? "user" : "chatgpt"}-color-legend`;
 
         return (
             <fieldset
                 key={index}
                 className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
             >
-                <legend
-                    id={legendId}
-                    className=" text-center p-1 w-24 rounded-md"
+                <legend className="sr-only">{`${userType} color settings`}</legend>
+                <div
+                    className="text-center p-1 w-24 rounded-md"
+                    aria-hidden="true"
                     style={{
                         backgroundColor:
                             liveSettings[
@@ -48,12 +48,8 @@ export function ColorControls({
                     }}
                 >
                     {`${userType} Color`}
-                </legend>
-                <div
-                    className="grid grid-cols-2 gap-1 w-full text-white"
-                    role="group"
-                    aria-labelledby={legendId}
-                >
+                </div>
+                <div className="grid grid-cols-2 gap-1 w-full text-white">
                     {colorSettings.map((setting, settingIndex) =>
                         mapSettingInputs(
                             setting,
@@ -62,6 +58,12 @@ export function ColorControls({
                             userType,
                         ),
                     )}
+                    <span className="rounded-md font-medium text-center p-0 m-0">
+                        BG
+                    </span>
+                    <span className="rounded-md font-medium text-center p-0 m-0">
+                        Text
+                    </span>
                 </div>
             </fieldset>
         );
@@ -77,7 +79,6 @@ export function ColorControls({
             isUser ? "User" : "NonUser"
         }Style`;
         const channelLabel = setting === "messageColor" ? "background" : "text";
-        const labelText = setting === "messageColor" ? "BG" : "Text";
 
         const handleOnChange = (
             e: React.ChangeEvent<HTMLInputElement>,
@@ -93,22 +94,15 @@ export function ColorControls({
         };
 
         return (
-            <div key={index} className="flex flex-col gap-1 w-full">
-                <label
-                    htmlFor={settingsKey}
-                    className="rounded-md font-medium text-center p-0 m-0"
-                >
-                    {labelText}
-                </label>
-                <input
-                    className="text-center w-full rounded-md h-8"
-                    type="color"
-                    id={settingsKey}
-                    aria-label={`${userType} ${channelLabel} color`}
-                    value={liveSettings[settingsKey]}
-                    onChange={(e) => handleOnChange(e, settingsKey)}
-                />
-            </div>
+            <input
+                key={index}
+                className="text-center w-full rounded-md h-8"
+                type="color"
+                id={settingsKey}
+                aria-label={`${userType} ${channelLabel} color`}
+                value={liveSettings[settingsKey]}
+                onChange={(e) => handleOnChange(e, settingsKey)}
+            />
         );
     };
 

--- a/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
+++ b/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
@@ -8,8 +8,13 @@ exports[`ColorControls component renders correctly 1`] = `
     className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
   >
     <legend
-      className=" text-center p-1 w-24 rounded-md"
-      id="user-color-legend"
+      className="sr-only"
+    >
+      User color settings
+    </legend>
+    <div
+      aria-hidden="true"
+      className="text-center p-1 w-24 rounded-md"
       style={
         Object {
           "backgroundColor": "#386d9f",
@@ -18,56 +23,49 @@ exports[`ColorControls component renders correctly 1`] = `
       }
     >
       User Color
-    </legend>
+    </div>
     <div
-      aria-labelledby="user-color-legend"
       className="grid grid-cols-2 gap-1 w-full text-white"
-      role="group"
     >
-      <div
-        className="flex flex-col gap-1 w-full"
+      <input
+        aria-label="User background color"
+        className="text-center w-full rounded-md h-8"
+        id="messageColorUserStyle"
+        onChange={[Function]}
+        type="color"
+        value="#386d9f"
+      />
+      <input
+        aria-label="User text color"
+        className="text-center w-full rounded-md h-8"
+        id="textColorUserStyle"
+        onChange={[Function]}
+        type="color"
+        value="#FFFFFF"
+      />
+      <span
+        className="rounded-md font-medium text-center p-0 m-0"
       >
-        <label
-          className="rounded-md font-medium text-center p-0 m-0"
-          htmlFor="messageColorUserStyle"
-        >
-          BG
-        </label>
-        <input
-          aria-label="User background color"
-          className="text-center w-full rounded-md h-8"
-          id="messageColorUserStyle"
-          onChange={[Function]}
-          type="color"
-          value="#386d9f"
-        />
-      </div>
-      <div
-        className="flex flex-col gap-1 w-full"
+        BG
+      </span>
+      <span
+        className="rounded-md font-medium text-center p-0 m-0"
       >
-        <label
-          className="rounded-md font-medium text-center p-0 m-0"
-          htmlFor="textColorUserStyle"
-        >
-          Text
-        </label>
-        <input
-          aria-label="User text color"
-          className="text-center w-full rounded-md h-8"
-          id="textColorUserStyle"
-          onChange={[Function]}
-          type="color"
-          value="#FFFFFF"
-        />
-      </div>
+        Text
+      </span>
     </div>
   </fieldset>
   <fieldset
     className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
   >
     <legend
-      className=" text-center p-1 w-24 rounded-md"
-      id="chatgpt-color-legend"
+      className="sr-only"
+    >
+      ChatGPT color settings
+    </legend>
+    <div
+      aria-hidden="true"
+      className="text-center p-1 w-24 rounded-md"
       style={
         Object {
           "backgroundColor": "#333333",
@@ -76,48 +74,36 @@ exports[`ColorControls component renders correctly 1`] = `
       }
     >
       ChatGPT Color
-    </legend>
+    </div>
     <div
-      aria-labelledby="chatgpt-color-legend"
       className="grid grid-cols-2 gap-1 w-full text-white"
-      role="group"
     >
-      <div
-        className="flex flex-col gap-1 w-full"
+      <input
+        aria-label="ChatGPT background color"
+        className="text-center w-full rounded-md h-8"
+        id="messageColorNonUserStyle"
+        onChange={[Function]}
+        type="color"
+        value="#333333"
+      />
+      <input
+        aria-label="ChatGPT text color"
+        className="text-center w-full rounded-md h-8"
+        id="textColorNonUserStyle"
+        onChange={[Function]}
+        type="color"
+        value="#FFFFFF"
+      />
+      <span
+        className="rounded-md font-medium text-center p-0 m-0"
       >
-        <label
-          className="rounded-md font-medium text-center p-0 m-0"
-          htmlFor="messageColorNonUserStyle"
-        >
-          BG
-        </label>
-        <input
-          aria-label="ChatGPT background color"
-          className="text-center w-full rounded-md h-8"
-          id="messageColorNonUserStyle"
-          onChange={[Function]}
-          type="color"
-          value="#333333"
-        />
-      </div>
-      <div
-        className="flex flex-col gap-1 w-full"
+        BG
+      </span>
+      <span
+        className="rounded-md font-medium text-center p-0 m-0"
       >
-        <label
-          className="rounded-md font-medium text-center p-0 m-0"
-          htmlFor="textColorNonUserStyle"
-        >
-          Text
-        </label>
-        <input
-          aria-label="ChatGPT text color"
-          className="text-center w-full rounded-md h-8"
-          id="textColorNonUserStyle"
-          onChange={[Function]}
-          type="color"
-          value="#FFFFFF"
-        />
-      </div>
+        Text
+      </span>
     </div>
   </fieldset>
 </div>


### PR DESCRIPTION
- Upgrade TypeScript to 4.9.5; align @types/node to 24.x; bump ts-loader for compatibility
- Restore popup button backgrounds by beating Tailwind preflight after type="button"
- Keep color-control fieldset semantics with a screen-reader-only legend so the visual layout stays intact
- Update docs, changelog, and snapshots

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
