### PR TITLE
Upgrade React to 18 and migrate to createRoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 -   Upgraded TypeScript to 4.9.5 and aligned `@types/node` to 24.x; bumped `ts-loader` for compatibility
 -   Upgraded Jest to 29.7 with matching `ts-jest`, `@types/jest`, and `jest-environment-jsdom`
 -   Replaced `jest-css-modules` with `identity-obj-proxy` for CSS module mocks
+-   Upgraded React and ReactDOM to 18.3; migrated popup and content-script mounts to `createRoot`
 
 ## [1.2.3] - 2025-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Full flow: [docs/architecture.md](docs/architecture.md). Settings model: [docs/f
 
 ## Conventions
 
--   **Language / UI**: TypeScript + React 17. Prefer functional components. Popup views/controls use named implementation files (`MessageEditor.tsx`) plus a barrel `index.ts`; shared UI under `src/components/` uses PascalCase filenames (`FormButtons.tsx`). Tests live under `__tests__/`.
+-   **Language / UI**: TypeScript + React 18. Prefer functional components. Popup views/controls use named implementation files (`MessageEditor.tsx`) plus a barrel `index.ts`; shared UI under `src/components/` uses PascalCase filenames (`FormButtons.tsx`). Tests live under `__tests__/`.
 -   **Folder roles**: `src/shared/` = cross-entry domain model, messaging contracts, and pure helpers. `src/lib/utilities/` = Chrome/DOM runtime adapters (storage, selectors, page automation). Do not merge these trees casually.
 -   **Styling**: Tailwind utility classes in TSX; CSS modules (`*.module.css`) for component-scoped rules; global styles via `app.css` + PostCSS/Tailwind.
 -   **Extension APIs**: Use raw `chrome.*` everywhere (popup, background, content, storage). Do not reintroduce `webextension-polyfill` without an explicit product need.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ Line endings: [`.gitattributes`](../.gitattributes) and Prettier `endOfLine: "lf
 
 TypeScript config: [`tsconfig.json`](../tsconfig.json) (`strict`, JSX react, path `@src/*`, `skipLibCheck`). ESLint: [`.eslintrc.js`](../.eslintrc.js). Prettier: [`.prettierrc.js`](../.prettierrc.js). Tailwind: [`tailwind.config.js`](../tailwind.config.js) + [`postcss.config.js`](../postcss.config.js). Webpack CSS pipeline uses `style-loader` + `css-loader` + `postcss-loader`.
 
-**Note:** Runtime is Node 24 with TypeScript **4.9.5** and `@types/node` **24.x**. Jest is on **29.x**. A TypeScript 5.x jump can wait for a dedicated PR (now unblocked by the Jest modernization).
+**Note:** Runtime is Node 24 with TypeScript **4.9.5**, React **18.3**, and `@types/node` **24.x**. Jest is on **29.x**. A TypeScript 5.x jump can wait for a dedicated PR.
 
 ## Loading the unpacked extension
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
             "version": "1.2.4",
             "license": "MIT",
             "dependencies": {
-                "react": "17.0.2",
-                "react-dom": "17.0.2"
+                "react": "18.3.1",
+                "react-dom": "18.3.1"
             },
             "devDependencies": {
                 "@types/chrome": "0.0.124",
                 "@types/jest": "29.5.14",
                 "@types/node": "24.13.3",
-                "@types/react": "17.0.75",
-                "@types/react-dom": "17.0.25",
-                "@types/react-test-renderer": "17.0.9",
+                "@types/react": "18.3.18",
+                "@types/react-dom": "18.3.5",
+                "@types/react-test-renderer": "18.3.1",
                 "@typescript-eslint/eslint-plugin": "4.33.0",
                 "@typescript-eslint/parser": "4.33.0",
                 "autoprefixer": "10.4.27",
@@ -33,7 +33,7 @@
                 "postcss": "8.5.19",
                 "postcss-loader": "6.2.1",
                 "prettier": "2.5.1",
-                "react-test-renderer": "17.0.2",
+                "react-test-renderer": "18.3.1",
                 "style-loader": "3.3.4",
                 "tailwindcss": "3.0.8",
                 "ts-jest": "29.4.6",
@@ -1544,44 +1544,40 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "17.0.75",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.75.tgz",
-            "integrity": "sha512-MSA+NzEzXnQKrqpO63CYqNstFjsESgvJAdAyyJ1n6ZQq/GLgf6nOfIKwk+Twuz0L1N6xPe+qz5xRCJrbhMaLsw==",
+            "version": "18.3.18",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+            "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
-                "@types/scheduler": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "17.0.25",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-            "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+            "version": "18.3.5",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+            "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
             "dev": true,
-            "dependencies": {
-                "@types/react": "^17"
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
             }
         },
         "node_modules/@types/react-test-renderer": {
-            "version": "17.0.9",
-            "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.9.tgz",
-            "integrity": "sha512-bOfxcu5oZ+KxvACScbkTwZ4eGCtZFTz4VZCOVAIfGbThxqiXSIGipKVG8ubaYBXquUSQROzNIUzviWdSnnAlzg==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+            "integrity": "sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/react": "^17"
+                "@types/react": "^18"
             }
         },
         "node_modules/@types/react/node_modules/csstype": {
             "version": "3.0.10",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
             "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-            "dev": true
-        },
-        "node_modules/@types/scheduler": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -7506,6 +7502,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8099,13 +8096,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/pretty-format/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8226,35 +8216,36 @@
             }
         },
         "node_modules/react": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-            "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "scheduler": "^0.20.2"
+                "scheduler": "^0.23.2"
             },
             "peerDependencies": {
-                "react": "17.0.2"
+                "react": "^18.3.1"
             }
         },
         "node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/react-shallow-renderer": {
             "version": "16.15.0",
@@ -8270,18 +8261,18 @@
             }
         },
         "node_modules/react-test-renderer": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-            "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+            "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "object-assign": "^4.1.1",
-                "react-is": "^17.0.2",
-                "react-shallow-renderer": "^16.13.1",
-                "scheduler": "^0.20.2"
+                "react-is": "^18.3.1",
+                "react-shallow-renderer": "^16.15.0",
+                "scheduler": "^0.23.2"
             },
             "peerDependencies": {
-                "react": "17.0.2"
+                "react": "^18.3.1"
             }
         },
         "node_modules/readdirp": {
@@ -8526,12 +8517,12 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-            "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.1.0"
             }
         },
         "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
         "@types/chrome": "0.0.124",
         "@types/jest": "29.5.14",
         "@types/node": "24.13.3",
-        "@types/react": "17.0.75",
-        "@types/react-dom": "17.0.25",
-        "@types/react-test-renderer": "17.0.9",
+        "@types/react": "18.3.18",
+        "@types/react-dom": "18.3.5",
+        "@types/react-test-renderer": "18.3.1",
         "@typescript-eslint/eslint-plugin": "4.33.0",
         "@typescript-eslint/parser": "4.33.0",
         "autoprefixer": "10.4.27",
@@ -59,7 +59,7 @@
         "postcss": "8.5.19",
         "postcss-loader": "6.2.1",
         "prettier": "2.5.1",
-        "react-test-renderer": "17.0.2",
+        "react-test-renderer": "18.3.1",
         "style-loader": "3.3.4",
         "tailwindcss": "3.0.8",
         "ts-jest": "29.4.6",
@@ -70,8 +70,8 @@
         "webpack-merge": "5.10.0"
     },
     "dependencies": {
-        "react": "17.0.2",
-        "react-dom": "17.0.2"
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
     },
     "overrides": {
         "braces": "3.0.3",

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot, Root } from "react-dom/client";
 import { ScrollToTop } from "./components/scrollToTop/ScrollToTop";
 import { getOptionsFromStorage, deleteAllChats } from "./lib/utilities";
 import { buildCss } from "./shared/utils";
@@ -60,8 +60,14 @@ const syncLayoutHelpers = (): void => {
     removeUnnecessarySpace({ userTextContainer, inputBoxContainer });
 };
 
+const scrollToTopRoots = new WeakMap<Element, Root>();
+
 const unmountScrollToTop = (mountPoint: Element): void => {
-    ReactDOM.unmountComponentAtNode(mountPoint);
+    const root = scrollToTopRoots.get(mountPoint);
+    if (root) {
+        root.unmount();
+        scrollToTopRoots.delete(mountPoint);
+    }
     mountPoint.remove();
 };
 
@@ -87,7 +93,9 @@ const syncScrollToTop = (): void => {
     const mountPoint = document.createElement("div");
     mountPoint.id = SCROLL_TO_TOP_MOUNT_ID;
     parentDiv.appendChild(mountPoint);
-    ReactDOM.render(React.createElement(ScrollToTop), mountPoint);
+    const root = createRoot(mountPoint);
+    scrollToTopRoots.set(mountPoint, root);
+    root.render(React.createElement(ScrollToTop));
 };
 
 const syncPageIntegrations = (): void => {

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { Popup } from "./Popup";
 import "../css/app.css";
 
@@ -9,7 +9,7 @@ const mountPopup = (): void => {
         console.error("Popup root #popup was not found");
         return;
     }
-    ReactDOM.render(<Popup />, root);
+    createRoot(root).render(<Popup />);
 };
 
 // popup.html historically loads js/popup.js in <head>, so wait for the body root.


### PR DESCRIPTION
- Upgrade React / ReactDOM to 18.3 with matching types and react-test-renderer
- Migrate popup and ScrollToTop mounts from ReactDOM.render to createRoot
- Track content-script roots in a WeakMap so remount/unmount stays correct on the 1s sync loop
- Update docs and changelog

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
