### PR TITLE
Audit ChatGPT Selectors and Functionality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*.zip
-          # Treat tags containing a hyphen (e.g. 1.2.4-RC1) as pre-releases.
+          # Treat tags containing a hyphen (e.g. 1.3.1-RC1) as pre-releases.
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Changelog
 
-## [1.2.4] - 2026-07-18
+## [1.3.1] - 2026-07-18
 
 ### Fixed
 
 -   Cancel now restores the last saved settings instead of built-in defaults
 -   Prevented a race where closing the popup before settings finished loading could overwrite saved options with defaults
 -   Merged stored settings with defaults so missing keys from older installs are filled in
--   Applied `messageButtonsVisibilityStyle: false` correctly after settings reload
 -   Prevented content-script console errors when ChatGPT layout nodes are missing
--   Made scroll-to-top remount correctly when ChatGPT replaces its scroll container
--   Made delete-all report success only after the ChatGPT UI flow completes
--   Stopped delete-all polling from throwing forever when buttons never appear
+-   Restored message colors, padding, radius, and widths against the current ChatGPT turn markup (`data-turn` / role attributes)
+-   Removed ChatGPT’s shared content-width cap so message and input-box width sliders can reach 100%
+-   Restored delete-all for the current Profile → Settings → Data controls flow, with reliable success/failure reporting
+-   Restored scroll-to-top on ChatGPT’s real scroll root and placed it beside the native scroll-to-bottom control
 -   Restored the color controls' original visual layout while preserving their accessible names
 -   Restored popup button backgrounds after `type="button"` lost to Tailwind preflight specificity
 
 ### Changed
 
 -   Made CSS generation deterministic by building styles from the complete settings object
--   Added regression coverage for generated CSS and boolean settings
+-   Added regression coverage for generated CSS
 -   Hardened the content-script 1s integration loop to skip missing DOM and avoid stale mounts
 -   Removed an unused content-script handshake message
 -   Delete-all now awaits the content-script result and uses a hostname-based ChatGPT tab check
@@ -29,6 +29,7 @@
 -   Hardened live-preview tab messaging against missing tabs / `runtime.lastError`
 -   Fixed popup mount so React waits for `#popup` (script no longer races ahead of the DOM)
 -   Colocated the `Settings` model and defaults; renamed the Chrome storage adapter for clearer ownership
+-   Storage reads and writes now keep only known settings keys
 -   Standardized popup prop naming on `liveSettings` / `setLiveSettings`
 -   Renamed popup views to named files (`Popup`, `MessageEditor`, `ColorControls`, `MessageSliderControls`)
 -   Renamed `colorControl` → `colorControls` and `scrollToTop.tsx` → `ScrollToTop.tsx`
@@ -39,9 +40,20 @@
 -   Upgraded Jest to 29.7 with matching `ts-jest`, `@types/jest`, and `jest-environment-jsdom`
 -   Replaced `jest-css-modules` with `identity-obj-proxy` for CSS module mocks
 -   Upgraded React and ReactDOM to 18.3; migrated popup and content-script mounts to `createRoot`
--   Added a development-only ChatGPT selector health check with copyable JSON results
+-   Added a development-only ChatGPT selector health check with copyable JSON results; probes track the current DOM
 -   Added explicit `build:dev` / `build:prod` flavors driven by one mode-aware Webpack config; production strips debug console calls
 -   Added concurrent development/production CI builds and automated tagged GitHub Releases with separate production and debugging artifacts; RC tags publish as pre-releases
+
+### Removed
+
+-   Removed the unused message-button visibility setting because ChatGPT now always displays message actions and the extension no longer provides a control for it
+-   Removed obsolete ChatGPT CSS helpers that no longer match the current DOM (legacy message-surface classes and old presentation-chain layout resets)
+
+## [1.3.0] - 2025-10-17
+
+### Changed
+
+-   Published the existing 1.2.3 build under the 1.3.0 release tag; no additional code changes were included and the packaged version metadata remained 1.2.3
 
 ## [1.2.3] - 2025-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Agent-oriented guide for working in this repository. For deeper detail, see [doc
 
 **ChatGPT Styler** is a Chromium Manifest V3 extension that customizes the ChatGPT UI (`chatgpt.com`). Users adjust message colors, widths, padding, border radius, and input-box width from a React popup. A content script injects generated CSS into the page, mounts a scroll-to-top control, and can drive ChatGPT’s “delete all chats” UI via DOM automation.
 
--   Package name / version: `chatgpt-styler` `1.2.3` ([`package.json`](package.json))
+-   Package name / version: `chatgpt-styler` `1.3.1` ([`package.json`](package.json))
 -   Store / product context: see [`README.md`](README.md)
 -   Release history: [`CHANGELOG.md`](CHANGELOG.md)
 
@@ -124,7 +124,7 @@ Full flow: [docs/architecture.md](docs/architecture.md). Settings model: [docs/f
 2. Update `CHANGELOG.md`.
 3. `npm run build:prod` and smoke-test unpacked `dist/` (build alone does **not** recreate manifest/HTML/icons).
 4. Run `npm run validate && npm run test:ci`.
-5. Push an RC tag such as `1.2.4-RC1` for a pre-release, or a final tag such as `1.2.4` after approval.
+5. Push an RC tag such as `1.3.1-RC1` for a pre-release, or a final tag such as `1.3.1` after approval.
 6. The Release workflow builds dev/prod concurrently and attaches both zips to a GitHub Release; only the prod zip is a store deliverable. See [docs/releases.md](docs/releases.md).
 
 ## What to avoid

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "chatgpt-styler",
     "description": "Extension to allow users to change the styling for their ChatGPT experience.",
-    "version": "1.2.4",
+    "version": "1.3.1",
     "action": {
         "default_icon": {
             "16": "icon-16.png",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ Dev vs prod: [`webpack.config.js`](../webpack.config.js) reads Webpack's `--mode
 -   Views under [`src/popup/views/messageEditor/`](../src/popup/views/messageEditor/) — active controls.
 -   Shared controls under [`src/components/`](../src/components/) — Header, FormButtons, DeleteAllChatsButton, etc.
 
-**Note:** Multi-page navigation (HomeMenu / MiscEditor / HomeButton) was removed from the source tree. `messageButtonsVisibilityStyle` remains in settings + CSS with no UI control for now.
+**Note:** Multi-page navigation (HomeMenu / MiscEditor / HomeButton) was removed from the source tree.
 
 ### Background service worker
 
@@ -92,7 +92,7 @@ This is the intentional “save when popup closes” path. Explicit Save in the 
 | [`settingsStorage.ts`](../src/lib/utilities/settingsStorage.ts)               | Get/set `options` under `chrome.storage.sync`                  |
 | [`stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts)              | Pure `buildCss(settings)`, `sendMessageToTab` for live preview |
 | [`messaging/`](../src/shared/messaging/)                                      | Typed popup / content / port message contracts                 |
-| [`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile menu → Settings → delete-all click sequence            |
+| [`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts)                 | Profile → Settings → Data controls → delete-all → confirm      |
 | [`chatDom.ts`](../src/lib/utilities/chatDom.ts)                               | Shared ChatGPT DOM selectors / mount ids                       |
 | [`removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts) | Remove Tailwind/layout classes that constrain width            |
 
@@ -143,17 +143,16 @@ sequenceDiagram
 ## Persistence model
 
 -   Key: `options` in `chrome.storage.sync`.
--   Shape and defaults: [`Settings` / `defaultSettings`](../src/shared/settings.ts) (string numeric-looking values for widths/padding/radius; hex colors; one boolean for button visibility).
+-   Shape and defaults: [`Settings` / `defaultSettings`](../src/shared/settings.ts) (string numeric-looking values for widths/padding/radius; hex colors).
 -   Storage adapter: [`settingsStorage.ts`](../src/lib/utilities/settingsStorage.ts), which merges stored values over defaults so new/missing keys are filled.
 
 ## Known implementation caveats
 
 These are **current code realities**, not goals:
 
-1. **No UI for `messageButtonsVisibilityStyle`** — the boolean still ships in storage defaults and `buildCss`, but nothing in the popup toggles it. Revisit if product wants that control back.
-2. **Intentional dual save paths** — Save writes immediately; closing the popup also persists the current live settings.
-3. **Delete-all DOM fragility** — automation still depends on ChatGPT’s menu markup and can time out when selectors drift; failures are now reported honestly instead of as false success. See [dom-integration.md](dom-integration.md).
-4. **General DOM fragility** — Styling and layout helpers also depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
+1. **Intentional dual save paths** — Save writes immediately; closing the popup also persists the current live settings.
+2. **Delete-all DOM fragility** — automation still depends on ChatGPT’s menu markup and can time out when selectors drift; failures are now reported honestly instead of as false success. See [dom-integration.md](dom-integration.md).
+3. **General DOM fragility** — Styling and layout helpers also depend on ChatGPT’s markup (`data-testid`, deep child selectors). Expect breakage when OpenAI ships UI changes; see [dom-integration.md](dom-integration.md).
 
 ## Related docs
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -117,7 +117,7 @@ Workflow: [`.github/workflows/release.yml`](../.github/workflows/release.yml).
 -   **Validation:** typecheck, lint, format check, and tests run once.
 -   **Builds:** production and development flavors build concurrently.
 -   **Outputs:** both zips are retained as workflow artifacts and attached to an automatically created GitHub Release.
--   Tags containing a hyphen (for example, `1.2.4-RC1`) become pre-releases; final tags such as `1.2.4` become normal releases.
+-   Tags containing a hyphen (for example, `1.3.1-RC1`) become pre-releases; final tags such as `1.3.1` become normal releases.
 -   The production zip is the Chrome Web Store deliverable. The development zip is for sideloading and diagnostics.
 -   The workflow does **not** publish to the Chrome Web Store.
 

--- a/docs/dom-integration.md
+++ b/docs/dom-integration.md
@@ -29,28 +29,25 @@ Always prefer updating selectors in the smallest surface that broke, then smoke-
 | Purpose              | Selector / target                                                                  |
 | -------------------- | ---------------------------------------------------------------------------------- |
 | Style injection      | `#custom-style` created under `document.head`                                      |
-| User text containers | `[data-testid^="conversation-turn-"]:nth-child(odd) > * > * > * > * > * > * > div` |
-| Input box container  | `#thread-bottom > * > div`                                                         |
-| Scroll-to-top parent | `div[role="presentation"] > div > div > div > div`                                 |
-| Mount node id        | `#scroll-to-top-mount`                                                             |
+| User text containers | `[data-message-author-role="user"]`                                            |
+| Input box container  | `#thread-bottom > * > div`                                                     |
+| Scroll-to-top parent | `[data-scroll-root]`                                                           |
+| Scroll-to-top mount host | `#thread-bottom-container [style*="--thread-scroll-to-bottom-banner-offset"]` |
+| Mount node id        | `#scroll-to-top-mount`                                                         |
 
 ### Generated CSS root ([`stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts))
 
 | Purpose                              | Selector pattern                                                          |
 | ------------------------------------ | ------------------------------------------------------------------------- |
-| All message bubbles                  | `[data-testid^="conversation-turn-"]` (variable `messageBubbles`)         |
-| User bubble background               | `...:nth-child(odd) > * > *`                                              |
-| Assistant bubble background          | `...:nth-child(even) > * > *`                                             |
-| User text color                      | `:nth-child(odd) .bg-token-message-surface`                               |
-| Assistant text color                 | Even turns: nested `div`, `p`, lists, code, headings                      |
-| Message max-width / padding / radius | `${messageBubbles} > * > div`                                             |
+| All message turns                    | `[data-testid^="conversation-turn-"]` (variable `messageBubbles`)         |
+| User bubble background / text / radius / padding / width | `[data-turn="user"] .user-message-bubble-color` |
+| Assistant message background / padding / width / radius | `[data-turn="assistant"] [data-message-author-role="assistant"]` |
+| Assistant text color                 | `[data-turn="assistant"]` nested `p`, lists, code, headings               |
 | Input form width                     | `form`                                                                    |
-| Message action buttons visibility    | `${messageBubbles} button`                                                |
+| Content width cap removal            | `[data-conversation-screenshot-content]`, `#thread-bottom > div > div > div > div` |
 | Code / composer helpers              | nth-child(2) under bubbles; `#composer-submit-button`                     |
-| Default surface / edit UI            | `.bg-token-message-surface`, `.hidden`, `.bg-token-main-surface-tertiary` |
-| Input chrome resets                  | `main > [role="presentation"] > div:nth-child(2) > ...`                   |
 
-Odd/even turn indexing assumes ChatGPT’s conversation list order; if that order flips, colors appear swapped (historically fixed in changelog entries).
+Turns are role-tagged via `data-turn="user"|"assistant"` (not odd/even sibling index). Odd/even broke after ChatGPT wrapped each turn in `data-turn-id-container`.
 
 ### Layout class removals ([`removeUnnecessarySpace.ts`](../src/lib/utilities/removeUnnecessarySpace.ts))
 
@@ -68,24 +65,26 @@ If ChatGPT renames these utilities, cleanup becomes a no-op and widths may look 
 
 ### Scroll to top ([`ScrollToTop.tsx`](../src/components/scrollToTop/ScrollToTop.tsx))
 
-| Purpose            | Selector                                                                                      |
-| ------------------ | --------------------------------------------------------------------------------------------- |
-| Scroll parent      | Same presentation chain as content script: `div[role="presentation"] > div > div > div > div` |
-| Injected button id | `#scroll-to-top-btn`                                                                          |
+| Purpose            | Selector / behavior                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| Scroll parent      | `[data-scroll-root]`                                                                              |
+| Mount host         | `#thread-bottom-container` control area (beside native scroll-to-bottom)                          |
+| Injected button id | `#scroll-to-top-btn`                                                                              |
 
-Uses site design tokens in button classes (`border-token-border-light`, `bg-token-main-surface-primary`, etc.) so the control blends with ChatGPT chrome.
+Uses ChatGPT page token/button classes plus known absolute positioning so the control sits beside the native scroll-to-bottom button.
 
 ### Delete all chats ([`deleteAllChats.ts`](../src/lib/utilities/deleteAllChats.ts))
 
 Comments in source note that selectors may need updates after domain HTML changes.
 
-| Step                   | Selector / action                                              |
-| ---------------------- | -------------------------------------------------------------- |
-| Detect history present | `div.group\\/sidebar > div:nth-child(3)` (must have children)  |
-| Open profile           | `[aria-label="Open Profile Menu"]` via pointerdown/pointerup   |
-| Open settings          | `[data-testid="settings-menu-item"]` click                     |
-| Delete all             | `[data-testid="delete-all-chats-button"]` (awaited, timed out) |
-| Confirm                | `[data-testid="confirm-delete-all-chats-button"]` (awaited)    |
+| Step                   | Selector / action                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| Detect history present | `#history a[href^="/c/"]` (at least one conversation link)                         |
+| Open profile           | Visible (non-`inert`) `[data-testid="accounts-profile-button"]` via pointer events |
+| Open settings          | `[data-testid="settings-menu-item"]` click                                         |
+| Open Data controls     | `[data-testid="data-controls-tab"]` click                                          |
+| Delete all             | `button.btn-danger-outline[aria-label^="Delete all"]` (awaited)                    |
+| Confirm                | `[data-testid="confirm-delete-all-chats-button"]` (awaited)                        |
 
 Popup gate: active tab hostname is `chatgpt.com` / `*.chatgpt.com` ([`DeleteAllChatsButton.tsx`](../src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx)). Automation uses bounded waits and always clears timers; SUCCESS is only returned after the confirm click.
 

--- a/docs/features-and-settings.md
+++ b/docs/features-and-settings.md
@@ -16,9 +16,7 @@ User-facing behavior and how settings become CSS on ChatGPT. Architecture contex
 | Delete all conversations         | DeleteAllChatsButton         | DOM automation on the active ChatGPT tab                                      |
 | Scroll to top                    | Content script + ScrollToTop | Floating button when the thread is scrolled                                   |
 | Layout cleanup                   | `removeUnnecessarySpace`     | Removes classes that constrain width / alignment                              |
-| Fixed CSS helpers                | `stylingFunctions`           | Code-snippet width, transparent edit box, hide default message surface, etc.  |
-
-`messageButtonsVisibilityStyle` remains in the settings schema and CSS output (default `true`) but has **no popup control** today. A future Misc-style toggle can wire it back up without a storage migration.
+| Fixed CSS helpers                | `stylingFunctions`           | Content width-cap removal, light-mode submit button color, and related helpers |
 
 ## Settings model
 
@@ -34,21 +32,19 @@ interface Settings {
     inputBoxMaxWidthStyle: string;
     textColorUserStyle: string;
     textColorNonUserStyle: string;
-    messageButtonsVisibilityStyle: boolean;
 }
 ```
 
-| Key                             | Default     |
-| ------------------------------- | ----------- |
-| `messageMaxWidthStyle`          | `"95"`      |
-| `messageColorUserStyle`         | `"#0084FF"` |
-| `messageColorNonUserStyle`      | `"#333333"` |
-| `messagePaddingStyle`           | `"10"`      |
-| `messageBorderRadiusStyle`      | `"5"`       |
-| `inputBoxMaxWidthStyle`         | `"94"`      |
-| `textColorUserStyle`            | `"#FFFFFF"` |
-| `textColorNonUserStyle`         | `"#FFFFFF"` |
-| `messageButtonsVisibilityStyle` | `true`      |
+| Key                        | Default     |
+| -------------------------- | ----------- |
+| `messageMaxWidthStyle`     | `"95"`      |
+| `messageColorUserStyle`    | `"#0084FF"` |
+| `messageColorNonUserStyle` | `"#333333"` |
+| `messagePaddingStyle`      | `"10"`      |
+| `messageBorderRadiusStyle` | `"5"`       |
+| `inputBoxMaxWidthStyle`    | `"94"`      |
+| `textColorUserStyle`       | `"#FFFFFF"` |
+| `textColorNonUserStyle`    | `"#FFFFFF"` |
 
 Storage key: `options` in `chrome.storage.sync`. Stored values are merged over `defaultSettings`, so missing keys from older installs receive current defaults.
 
@@ -83,11 +79,10 @@ The popup does not forward its initial defaults to the background until storage 
 [`src/shared/utils/stylingFunctions.ts`](../src/shared/utils/stylingFunctions.ts) is the single place settings become CSS.
 
 1. `buildCss(settings)` is a **pure** function: the returned CSS string depends only on the provided `Settings` object (no module-level mutable fragments).
-2. Boolean settings such as `messageButtonsVisibilityStyle: false` are applied correctly (`visibility: invisible`).
-3. Fixed helper rules (code-snippet width, hide default message surface, show edit button, transparent edit box, input padding/max-width resets) are always included.
-4. Primary selector root: `[data-testid^="conversation-turn-"]`.
-    - User turns: `:nth-child(odd)`
-    - Assistant turns: `:nth-child(even)`
+2. Fixed helper rules (content width-cap removal, turn sizing helpers, light-mode submit button color) are always included.
+3. Primary selector root: `[data-testid^="conversation-turn-"]`.
+    - User turns: `[data-turn="user"]`
+    - Assistant turns: `[data-turn="assistant"]`
 
 `updateStyles(settings)` remains as a thin alias of `buildCss` for compatibility.
 
@@ -105,7 +100,8 @@ Content script applies `arg` as `customStyle.textContent` — it does not re-par
 
 [`src/components/scrollToTop/ScrollToTop.tsx`](../src/components/scrollToTop/ScrollToTop.tsx), mounted by the content script:
 
--   Finds ChatGPT’s scroll container under `div[role="presentation"] > ...`.
+-   Finds ChatGPT’s scroll container via `[data-scroll-root]`.
+-   Mounts beside the native scroll-to-bottom control under `#thread-bottom-container`.
 -   Shows a circular button when `scrollTop !== 0`.
 -   Smooth-scrolls to top; hides the button while scrolling.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,22 +17,22 @@ The workflow does **not** publish to the Chrome Web Store.
 
 ## Release candidate
 
-Use an incrementing tag such as `1.2.4-RC1`. A hyphenated tag is automatically published as a GitHub **pre-release**.
+Use an incrementing tag such as `1.3.1-RC1`. A hyphenated tag is automatically published as a GitHub **pre-release**.
 
 The tag must point to a pushed commit that includes the release workflow. From the release branch:
 
 ```bash
 git push -u origin HEAD
-git tag 1.2.4-RC1
-git push origin 1.2.4-RC1
+git tag 1.3.1-RC1
+git push origin 1.3.1-RC1
 ```
 
 After the workflow passes:
 
 1. Open the pre-release on GitHub.
-2. Download and unpack `dist-1.2.4-RC1.zip`.
+2. Download and unpack `dist-1.3.1-RC1.zip`.
 3. Load its `dist/` directory as an unpacked extension and smoke-test it on `chatgpt.com`.
-4. Use `dist-1.2.4-RC1-dev.zip` only when testing dev-only diagnostics.
+4. Use `dist-1.3.1-RC1-dev.zip` only when testing dev-only diagnostics.
 
 Use a new tag (`RC2`, `RC3`, and so on) for each candidate. Do not move or reuse a published tag.
 
@@ -52,8 +52,8 @@ Create a final tag without a hyphen:
 ```bash
 git switch main
 git pull --ff-only
-git tag 1.2.4
-git push origin 1.2.4
+git tag 1.3.1
+git push origin 1.3.1
 ```
 
 The workflow publishes a normal GitHub Release, generates release notes, and attaches the production and development zips. Download the production zip for Chrome Web Store submission.
@@ -63,7 +63,7 @@ The workflow publishes a normal GitHub Release, generates release notes, and att
 Prefer fixing the branch and creating the next RC tag. If an unpublished local tag is wrong, delete it with:
 
 ```bash
-git tag -d 1.2.4-RC1
+git tag -d 1.3.1-RC1
 ```
 
 Deleting a pushed tag or published GitHub Release is disruptive and should be reserved for genuinely invalid releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chatgpt-styler",
-    "version": "1.2.4",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chatgpt-styler",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chatgpt-styler",
-    "version": "1.2.4",
+    "version": "1.3.1",
     "description": "Extension to allow users to change the styling for their ChatGPT experience.",
     "main": "index.js",
     "packageManager": "npm@11.16.0",

--- a/src/components/formButtons/__tests__/formButtons.test.tsx
+++ b/src/components/formButtons/__tests__/formButtons.test.tsx
@@ -12,7 +12,6 @@ const settings = {
     inputBoxMaxWidthStyle: "",
     textColorUserStyle: "",
     textColorNonUserStyle: "",
-    messageButtonsVisibilityStyle: false,
 };
 
 describe("FormButtons", () => {

--- a/src/components/scrollToTop/ScrollToTop.tsx
+++ b/src/components/scrollToTop/ScrollToTop.tsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { CHAT_SCROLL_PARENT_SELECTOR } from "@src/lib/utilities/chatDom";
+import {
+    CHAT_SCROLL_PARENT_SELECTOR,
+    SCROLL_TO_TOP_BUTTON_CLASS_NAME,
+    SCROLL_TO_TOP_BUTTON_STYLE,
+} from "@src/lib/utilities/chatDom";
 
 const getScrollParent = (): HTMLElement | null => {
     const node = document.querySelector(CHAT_SCROLL_PARENT_SELECTOR);
@@ -48,9 +52,8 @@ export const ScrollToTop = (): JSX.Element => {
         <>
             {isShowingScrollToTopButton && !isScrollingToTop && (
                 <button
-                    className={
-                        "cursor-pointer absolute z-10 rounded-full bg-clip-padding border text-token-text-secondary border-token-border-light left-1/2 rotate-180 translate-x-1/2 bg-token-main-surface-primary w-8 h-8 flex items-center justify-center bottom-5"
-                    }
+                    className={SCROLL_TO_TOP_BUTTON_CLASS_NAME}
+                    style={SCROLL_TO_TOP_BUTTON_STYLE}
                     onClick={scrollToTop}
                     id="scroll-to-top-btn"
                     type="button"
@@ -66,18 +69,18 @@ export const ScrollToTop = (): JSX.Element => {
 const UpArrow = (): JSX.Element => {
     return (
         <svg
-            width="24"
-            height="24"
+            width="20"
+            height="20"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            className="icon-md text-token-text-primary"
+            className="icon text-token-text-primary"
             aria-hidden="true"
         >
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
-                d="M12 21C11.7348 21 11.4804 20.8946 11.2929 20.7071L4.29289 13.7071C3.90237 13.3166 3.90237 12.6834 4.29289 12.2929C4.68342 11.9024 5.31658 11.9024 5.70711 12.2929L11 17.5858V4C11 3.44772 11.4477 3 12 3C12.5523 3 13 3.44772 13 4V17.5858L18.2929 12.2929C18.6834 11.9024 19.3166 11.9024 19.7071 12.2929C20.0976 12.6834 20.0976 13.3166 19.7071 13.7071L12.7071 20.7071C12.5196 20.8946 12.2652 21 12 21Z"
+                d="M12 3C12.2652 3 12.5196 3.10536 12.7071 3.29289L19.7071 10.2929C20.0976 10.6834 20.0976 11.3166 19.7071 11.7071C19.3166 12.0976 18.6834 12.0976 18.2929 11.7071L13 6.41421V20C13 20.5523 12.5523 21 12 21C11.4477 21 11 20.5523 11 20V6.41421L5.70711 11.7071C5.31658 12.0976 4.68342 12.0976 4.29289 11.7071C3.90237 11.3166 3.90237 10.6834 4.29289 10.2929L11.2929 3.29289C11.4804 3.10536 11.7348 3 12 3Z"
                 fill="currentColor"
             ></path>
         </svg>

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -11,6 +11,7 @@ import { removeUnnecessarySpace } from "@src/lib/utilities";
 import {
     CHAT_SCROLL_PARENT_SELECTOR,
     INPUT_BOX_CONTAINER_SELECTOR,
+    SCROLL_CONTROL_HOST_SELECTOR,
     SCROLL_TO_TOP_MOUNT_ID,
     USER_TEXT_CONTAINER_SELECTOR,
 } from "@src/lib/utilities/chatDom";
@@ -105,17 +106,21 @@ const unmountScrollToTop = (mountPoint: Element): void => {
 };
 
 const syncScrollToTop = (): void => {
-    const parentDiv = document.querySelector(CHAT_SCROLL_PARENT_SELECTOR);
+    const scrollParent = document.querySelector(CHAT_SCROLL_PARENT_SELECTOR);
+    const mountHost = document.querySelector(SCROLL_CONTROL_HOST_SELECTOR);
     const existingMount = document.getElementById(SCROLL_TO_TOP_MOUNT_ID);
 
-    if (!(parentDiv instanceof HTMLElement)) {
+    if (
+        !(scrollParent instanceof HTMLElement) ||
+        !(mountHost instanceof HTMLElement)
+    ) {
         if (existingMount) {
             unmountScrollToTop(existingMount);
         }
         return;
     }
 
-    if (existingMount && parentDiv.contains(existingMount)) {
+    if (existingMount && mountHost.contains(existingMount)) {
         return;
     }
 
@@ -125,7 +130,7 @@ const syncScrollToTop = (): void => {
 
     const mountPoint = document.createElement("div");
     mountPoint.id = SCROLL_TO_TOP_MOUNT_ID;
-    parentDiv.appendChild(mountPoint);
+    mountHost.appendChild(mountPoint);
     const root = createRoot(mountPoint);
     scrollToTopRoots.set(mountPoint, root);
     root.render(React.createElement(ScrollToTop));

--- a/src/lib/utilities/__tests__/checkSelectors.test.ts
+++ b/src/lib/utilities/__tests__/checkSelectors.test.ts
@@ -14,12 +14,15 @@ describe("checkSelectors", () => {
     it("passes required probes when expected nodes are present", () => {
         document.body.innerHTML = `
             <div data-testid="conversation-turn-1"></div>
+            <div data-scroll-root></div>
+            <div id="thread-bottom-container">
+                <div style="--thread-scroll-to-bottom-banner-offset: 0px;"></div>
+            </div>
             <div id="thread-bottom"><div><div></div></div></div>
             <form></form>
             <button id="composer-submit-button"></button>
-            <div role="presentation"><div><div><div><div></div></div></div></div></div>
             <style id="custom-style"></style>
-            <button aria-label="Open Profile Menu"></button>
+            <div data-testid="accounts-profile-button" role="button"></div>
         `;
 
         const report = checkSelectors(document);

--- a/src/lib/utilities/__tests__/deleteAllChats.test.ts
+++ b/src/lib/utilities/__tests__/deleteAllChats.test.ts
@@ -1,22 +1,50 @@
-import { deleteAllChats } from "../deleteAllChats";
+import { deleteAllChats, deleteAllChatsRuntime } from "../deleteAllChats";
 
 const setHtml = (html: string): void => {
     document.body.innerHTML = html;
 };
 
+const fullFlowHtml = `
+    <div id="history"><ul><li><a href="/c/abc">chat</a></li></ul></div>
+    <div data-testid="accounts-profile-button" role="button"></div>
+    <div data-testid="settings-menu-item" role="menuitem">Settings</div>
+    <div role="dialog" data-state="open">
+        <button
+            data-testid="data-controls-tab"
+            role="tab"
+            data-state="active"
+            aria-selected="true"
+        >
+            Data controls
+        </button>
+        <button class="btn btn-danger-outline" aria-label="Delete all Delete all chats">
+            Delete all
+        </button>
+        <button data-testid="confirm-delete-all-chats-button">Confirm deletion</button>
+    </div>
+`;
+
 describe("deleteAllChats", () => {
+    let reloadSpy: jest.SpyInstance;
+
     beforeEach(() => {
         jest.useFakeTimers();
         document.body.innerHTML = "";
+        reloadSpy = jest
+            .spyOn(deleteAllChatsRuntime, "reload")
+            .mockImplementation(() => undefined);
     });
 
     afterEach(() => {
         jest.runOnlyPendingTimers();
         jest.useRealTimers();
+        reloadSpy.mockRestore();
     });
 
     it("fails when chat history is missing", async () => {
-        setHtml(`<button aria-label="Open Profile Menu"></button>`);
+        setHtml(
+            `<div data-testid="accounts-profile-button" role="button"></div>`,
+        );
 
         await expect(deleteAllChats()).resolves.toEqual({
             status: "FAILURE",
@@ -26,11 +54,7 @@ describe("deleteAllChats", () => {
 
     it("fails when the profile button is missing", async () => {
         setHtml(`
-            <div class="group/sidebar">
-                <div></div>
-                <div></div>
-                <div><div>chat</div></div>
-            </div>
+            <div id="history"><ul><li><a href="/c/abc">chat</a></li></ul></div>
         `);
 
         await expect(deleteAllChats()).resolves.toEqual({
@@ -40,37 +64,50 @@ describe("deleteAllChats", () => {
     });
 
     it("completes the full delete flow when UI nodes are present", async () => {
-        setHtml(`
-            <div class="group/sidebar">
-                <div></div>
-                <div></div>
-                <div><div>chat</div></div>
-            </div>
-            <button aria-label="Open Profile Menu"></button>
-            <button data-testid="settings-menu-item"></button>
-            <button data-testid="delete-all-chats-button"></button>
-            <button data-testid="confirm-delete-all-chats-button"></button>
-        `);
+        setHtml(fullFlowHtml);
 
         const confirm = document.querySelector(
             '[data-testid="confirm-delete-all-chats-button"]',
-        ) as HTMLButtonElement;
-        const clickSpy = jest.spyOn(confirm, "click");
+        ) as HTMLElement;
+        const clickSpy = jest.spyOn(confirm, "dispatchEvent");
 
         await expect(deleteAllChats()).resolves.toEqual({
             status: "SUCCESS",
         });
         expect(clickSpy).toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+        expect(reloadSpy).toHaveBeenCalled();
+    });
+
+    it("skips the inert (collapsed-rail) profile button", async () => {
+        setHtml(`
+            <nav inert>
+                <div data-testid="accounts-profile-button" role="button" id="rail"></div>
+            </nav>
+            ${fullFlowHtml}
+        `);
+
+        const railButton = document.getElementById("rail") as HTMLElement;
+        const profileButtons = document.querySelectorAll(
+            '[data-testid="accounts-profile-button"]',
+        );
+        const visible = profileButtons[1] as HTMLElement;
+        const railSpy = jest.spyOn(railButton, "dispatchEvent");
+        const visibleSpy = jest.spyOn(visible, "dispatchEvent");
+
+        await expect(deleteAllChats()).resolves.toEqual({
+            status: "SUCCESS",
+        });
+        expect(visibleSpy).toHaveBeenCalled();
+        expect(railSpy).not.toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+        expect(reloadSpy).toHaveBeenCalled();
     });
 
     it("fails with a timeout when a later step never appears", async () => {
         setHtml(`
-            <div class="group/sidebar">
-                <div></div>
-                <div></div>
-                <div><div>chat</div></div>
-            </div>
-            <button aria-label="Open Profile Menu"></button>
+            <div id="history"><ul><li><a href="/c/abc">chat</a></li></ul></div>
+            <div data-testid="accounts-profile-button" role="button"></div>
         `);
 
         const resultPromise = deleteAllChats();

--- a/src/lib/utilities/chatDom.ts
+++ b/src/lib/utilities/chatDom.ts
@@ -1,9 +1,40 @@
-export const CHAT_SCROLL_PARENT_SELECTOR =
-    'div[role="presentation"] > div > div > div > div';
+// Stable attribute on ChatGPT's conversation scrollport (overflow-y: auto).
+export const CHAT_SCROLL_PARENT_SELECTOR = "[data-scroll-root]";
 
-export const USER_TEXT_CONTAINER_SELECTOR =
-    '[data-testid^="conversation-turn-"]:nth-child(odd) > * > * > * > * > * > * > div';
+// Parent of ChatGPT's scroll-to-bottom control (`relative mx-auto h-0`).
+export const SCROLL_CONTROL_HOST_SELECTOR =
+    '#thread-bottom-container [style*="--thread-scroll-to-bottom-banner-offset"]';
+
+export const USER_TEXT_CONTAINER_SELECTOR = '[data-message-author-role="user"]';
 
 export const INPUT_BOX_CONTAINER_SELECTOR = "#thread-bottom > * > div";
 
 export const SCROLL_TO_TOP_MOUNT_ID = "scroll-to-top-mount";
+
+/**
+ * Known CSS from ChatGPT's native scroll-to-bottom control.
+ * Native applies the same bottom calc on BOTH the absolute wrapper and the
+ * absolute button inside it, so the effective lift is 2× that value.
+ * left is shifted +2.5rem so we sit beside the centered native button
+ * (32px button + 8px gap = 40px = 2.5rem between centers).
+ */
+export const SCROLL_TO_TOP_BUTTON_STYLE: Readonly<Record<string, string>> = {
+    position: "absolute",
+    left: "calc(50% + 2.5rem)",
+    bottom: "calc(100% + 6 * var(--spacing) + 2 * var(--thread-scroll-to-bottom-banner-offset, 0px))",
+    transform: "translateX(-50%)",
+    zIndex: "10",
+    width: "32px",
+    height: "32px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    cursor: "pointer",
+    pointerEvents: "auto",
+    borderRadius: "9999px",
+    overflow: "hidden",
+};
+
+// Visual utilities that already exist on chatgpt.com (no absolute placement).
+export const SCROLL_TO_TOP_BUTTON_CLASS_NAME =
+    "btn-secondary bg-token-bg-primary/65! hover:bg-token-main-surface-secondary/75! shadow-short box-content backdrop-blur-[2px] backdrop-filter sm:shadow-md dark:shadow-none! outline-hidden select-none";

--- a/src/lib/utilities/checkSelectors.ts
+++ b/src/lib/utilities/checkSelectors.ts
@@ -2,12 +2,14 @@ import { SelectorCheckItem, SelectorCheckReport } from "@src/shared/messaging";
 import {
     CHAT_SCROLL_PARENT_SELECTOR,
     INPUT_BOX_CONTAINER_SELECTOR,
+    SCROLL_CONTROL_HOST_SELECTOR,
     SCROLL_TO_TOP_MOUNT_ID,
     USER_TEXT_CONTAINER_SELECTOR,
 } from "./chatDom";
 import {
     CHAT_HISTORY_SELECTOR,
     CONFIRM_DELETE_BUTTON_SELECTOR,
+    DATA_CONTROLS_TAB_SELECTOR,
     DELETE_ALL_BUTTON_SELECTOR,
     PROFILE_BUTTON_SELECTOR,
     SETTINGS_MENU_ITEM_SELECTOR,
@@ -42,7 +44,7 @@ export const SELECTOR_PROBES: SelectorProbe[] = [
     },
     {
         id: "userTextContainers",
-        label: "User text containers",
+        label: "User message containers",
         selector: USER_TEXT_CONTAINER_SELECTOR,
         expectAtLeast: 0,
         optional: true,
@@ -61,14 +63,21 @@ export const SELECTOR_PROBES: SelectorProbe[] = [
     },
     {
         id: "composerSubmit",
-        label: "Composer submit button",
+        label: "Composer submit button (when text entered)",
         selector: "#composer-submit-button",
-        expectAtLeast: 1,
+        expectAtLeast: 0,
+        optional: true,
     },
     {
         id: "scrollParent",
-        label: "Scroll-to-top parent",
+        label: "Scroll-to-top parent ([data-scroll-root])",
         selector: CHAT_SCROLL_PARENT_SELECTOR,
+        expectAtLeast: 1,
+    },
+    {
+        id: "threadBottomContainer",
+        label: "Native scroll-control host (scroll-to-top mount host)",
+        selector: SCROLL_CONTROL_HOST_SELECTOR,
         expectAtLeast: 1,
     },
     {
@@ -86,7 +95,7 @@ export const SELECTOR_PROBES: SelectorProbe[] = [
     },
     {
         id: "chatHistory",
-        label: "Sidebar chat history",
+        label: "Sidebar chat history (conversations)",
         selector: CHAT_HISTORY_SELECTOR,
         expectAtLeast: 0,
         optional: true,
@@ -99,21 +108,28 @@ export const SELECTOR_PROBES: SelectorProbe[] = [
     },
     {
         id: "settingsMenu",
-        label: "Settings menu item",
+        label: "Settings menu item (when profile menu open)",
         selector: SETTINGS_MENU_ITEM_SELECTOR,
         expectAtLeast: 0,
         optional: true,
     },
     {
+        id: "dataControlsTab",
+        label: "Data controls tab (when Settings open)",
+        selector: DATA_CONTROLS_TAB_SELECTOR,
+        expectAtLeast: 0,
+        optional: true,
+    },
+    {
         id: "deleteAll",
-        label: "Delete-all button",
+        label: "Delete-all button (on Data controls)",
         selector: DELETE_ALL_BUTTON_SELECTOR,
         expectAtLeast: 0,
         optional: true,
     },
     {
         id: "confirmDelete",
-        label: "Confirm delete-all button",
+        label: "Confirm delete-all button (dialog)",
         selector: CONFIRM_DELETE_BUTTON_SELECTOR,
         expectAtLeast: 0,
         optional: true,

--- a/src/lib/utilities/deleteAllChats.ts
+++ b/src/lib/utilities/deleteAllChats.ts
@@ -5,13 +5,29 @@ export type DeleteAllChatsResult =
 const POLL_INTERVAL_MS = 100;
 const DEFAULT_TIMEOUT_MS = 10000;
 
-export const CHAT_HISTORY_SELECTOR = "div.group\\/sidebar > div:nth-child(3)";
-export const PROFILE_BUTTON_SELECTOR = '[aria-label="Open Profile Menu"]';
+export const CHAT_HISTORY_SELECTOR = '#history a[href^="/c/"]';
+export const PROFILE_BUTTON_SELECTOR =
+    '[data-testid="accounts-profile-button"]';
 export const SETTINGS_MENU_ITEM_SELECTOR = '[data-testid="settings-menu-item"]';
+export const DATA_CONTROLS_TAB_SELECTOR =
+    '[role="dialog"][data-state="open"] [data-testid="data-controls-tab"]';
+/** No data-testid on the current ChatGPT button; match the danger outline label. */
 export const DELETE_ALL_BUTTON_SELECTOR =
-    '[data-testid="delete-all-chats-button"]';
+    '[role="dialog"][data-state="open"] button.btn-danger-outline[aria-label^="Delete all"]';
 export const CONFIRM_DELETE_BUTTON_SELECTOR =
-    '[data-testid="confirm-delete-all-chats-button"]';
+    '[role="dialog"][data-state="open"] [data-testid="confirm-delete-all-chats-button"]';
+
+/**
+ * ChatGPT renders two profile buttons: one in the collapsed rail
+ * (`#stage-sidebar-tiny-bar`, marked `inert`) and the visible one in the
+ * expanded sidebar. Pick the interactive (non-inert) button so the menu opens.
+ */
+const findVisibleProfileButton = (): HTMLElement | null => {
+    const buttons = Array.from(
+        document.querySelectorAll<HTMLElement>(PROFILE_BUTTON_SELECTOR),
+    );
+    return buttons.find((el) => !el.closest("[inert]")) ?? buttons[0] ?? null;
+};
 
 const waitForElement = <T extends Element>(
     selector: string,
@@ -48,78 +64,112 @@ const waitForElement = <T extends Element>(
     });
 };
 
-const openProfileMenu = (profileButton: HTMLElement): void => {
-    // pointerdown/up are required for ChatGPT's profile menu in the browser.
-    // Fall back to mouse events in test environments without PointerEvent.
-    const eventInit: MouseEventInit = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        button: 0,
-    };
+const mouseEventInit = (): MouseEventInit => ({
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    button: 0,
+});
+
+/**
+ * ChatGPT / Radix controls often ignore a bare MouseEvent("click").
+ * Mirror a real pointer interaction, then call the native click() hook.
+ */
+const activateElement = (element: HTMLElement): void => {
+    if (typeof element.scrollIntoView === "function") {
+        element.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+    const eventInit = mouseEventInit();
 
     if (typeof PointerEvent !== "undefined") {
-        profileButton.dispatchEvent(
+        element.dispatchEvent(
             new PointerEvent("pointerdown", {
                 ...eventInit,
                 pointerType: "mouse",
             }),
         );
-        profileButton.dispatchEvent(
+    }
+
+    // Radix Tabs activates on mousedown. Programmatically dispatched pointer
+    // events do not synthesize their corresponding mouse events.
+    element.dispatchEvent(new MouseEvent("mousedown", eventInit));
+
+    if (typeof PointerEvent !== "undefined") {
+        element.dispatchEvent(
             new PointerEvent("pointerup", {
                 ...eventInit,
                 pointerType: "mouse",
             }),
         );
-        return;
     }
+    element.dispatchEvent(new MouseEvent("mouseup", eventInit));
 
-    profileButton.dispatchEvent(new MouseEvent("mousedown", eventInit));
-    profileButton.dispatchEvent(new MouseEvent("mouseup", eventInit));
-    profileButton.dispatchEvent(new MouseEvent("click", eventInit));
+    // HTMLElement.click() follows the native click path through React's
+    // delegated handler. Do not dispatch an additional click event.
+    element.click();
+};
+
+const openProfileMenu = (profileButton: HTMLElement): void => {
+    activateElement(profileButton);
+};
+
+/** Runtime hooks; `reload` is stubbed in unit tests (jsdom locks location.reload). */
+export const deleteAllChatsRuntime = {
+    reload: (): void => {
+        window.location.reload();
+    },
 };
 
 /**
- * Drives ChatGPT's native delete-all UI. Resolves only after the confirm click,
- * or with FAILURE when a step is missing / times out. Intervals are always cleared.
+ * Drives ChatGPT's native delete-all UI:
+ * Profile → Settings → Data controls → Delete all → Confirm.
+ * Resolves only after the confirm click, or with FAILURE when a step is
+ * missing / times out. Intervals are always cleared.
  */
 export const deleteAllChats = async (): Promise<DeleteAllChatsResult> => {
     try {
-        const chatHistory = document.querySelector(CHAT_HISTORY_SELECTOR);
-        if (!chatHistory || chatHistory.children.length === 0) {
+        const chatHistory = document.querySelectorAll(CHAT_HISTORY_SELECTOR);
+        if (chatHistory.length === 0) {
             return { status: "FAILURE", message: "No chat history found" };
         }
 
-        const profileButton = document.querySelector(
-            PROFILE_BUTTON_SELECTOR,
-        ) as HTMLButtonElement | null;
+        const profileButton = findVisibleProfileButton();
         if (!profileButton) {
             return { status: "FAILURE", message: "Profile button not found!" };
         }
 
         openProfileMenu(profileButton);
 
-        const settingsMenuItem = await waitForElement<HTMLButtonElement>(
+        const settingsMenuItem = await waitForElement<HTMLElement>(
             SETTINGS_MENU_ITEM_SELECTOR,
         );
-        settingsMenuItem.click();
+        activateElement(settingsMenuItem);
 
-        const deleteAllChatsButton = await waitForElement<HTMLButtonElement>(
+        const dataControlsTab = await waitForElement<HTMLElement>(
+            DATA_CONTROLS_TAB_SELECTOR,
+        );
+        activateElement(dataControlsTab);
+
+        // Ensure the tab actually became active before looking for Delete all.
+        await waitForElement<HTMLElement>(
+            `${DATA_CONTROLS_TAB_SELECTOR}[data-state="active"], ${DATA_CONTROLS_TAB_SELECTOR}[aria-selected="true"]`,
+        );
+
+        const deleteAllChatsButton = await waitForElement<HTMLElement>(
             DELETE_ALL_BUTTON_SELECTOR,
         );
-        deleteAllChatsButton.dispatchEvent(
-            new MouseEvent("click", {
-                bubbles: true,
-                cancelable: true,
-                view: window,
-                button: 0,
-            }),
-        );
+        activateElement(deleteAllChatsButton);
 
-        const confirmDeleteButton = await waitForElement<HTMLButtonElement>(
+        const confirmDeleteButton = await waitForElement<HTMLElement>(
             CONFIRM_DELETE_BUTTON_SELECTOR,
         );
-        confirmDeleteButton.click();
+        activateElement(confirmDeleteButton);
+
+        // ChatGPT can leave the deleted conversation open; reload clears it.
+        // Defer so the popup still receives SUCCESS before navigation.
+        window.setTimeout(() => {
+            deleteAllChatsRuntime.reload();
+        }, 0);
 
         return { status: "SUCCESS" };
     } catch (error) {

--- a/src/lib/utilities/settingsStorage.ts
+++ b/src/lib/utilities/settingsStorage.ts
@@ -1,17 +1,27 @@
 import { defaultSettings, Settings } from "@src/shared/settings";
 
+const pickSettings = (stored: Partial<Settings> | undefined): Settings => {
+    const options = { ...defaultSettings };
+    if (!stored) return options;
+
+    (Object.keys(defaultSettings) as Array<keyof Settings>).forEach((key) => {
+        const value = stored[key];
+        if (value !== undefined) {
+            options[key] = value as Settings[typeof key];
+        }
+    });
+
+    return options;
+};
+
 export const getOptionsFromStorage = (
     callback: (options: Settings) => void,
 ): void => {
     chrome.storage.sync.get(["options"], (result) => {
-        const options: Settings = {
-            ...defaultSettings,
-            ...(result.options || {}),
-        };
-        callback(options);
+        callback(pickSettings(result.options));
     });
 };
 
 export const saveOptionsToStorage = (options: Settings): void => {
-    chrome.storage.sync.set({ options });
+    chrome.storage.sync.set({ options: pickSettings(options) });
 };

--- a/src/popup/views/messageEditor/__tests__/messageEditor.test.tsx
+++ b/src/popup/views/messageEditor/__tests__/messageEditor.test.tsx
@@ -21,7 +21,6 @@ describe("MessageEditor Component", () => {
             inputBoxMaxWidthStyle: "",
             textColorUserStyle: "",
             textColorNonUserStyle: "",
-            messageButtonsVisibilityStyle: true,
         },
         setLiveSettings: jest.fn(),
     };

--- a/src/popup/views/messageEditor/components/colorControls/__tests__/colorControls.test.tsx
+++ b/src/popup/views/messageEditor/components/colorControls/__tests__/colorControls.test.tsx
@@ -10,7 +10,6 @@ test("ColorControls component renders correctly", () => {
         messageBorderRadiusStyle: "5",
         messageColorUserStyle: "#386d9f",
         messageColorNonUserStyle: "#333333",
-        messageButtonsVisibilityStyle: false,
         inputBoxMaxWidthStyle: "94",
         textColorUserStyle: "#FFFFFF",
         textColorNonUserStyle: "#FFFFFF",

--- a/src/popup/views/messageEditor/components/messageSliderControls/__tests__/messageSliderControls.test.tsx
+++ b/src/popup/views/messageEditor/components/messageSliderControls/__tests__/messageSliderControls.test.tsx
@@ -21,7 +21,6 @@ describe("MessageSliderControls component", () => {
                         messageBorderRadiusStyle: "5",
                         messageColorUserStyle: "#386d9f",
                         messageColorNonUserStyle: "#333333",
-                        messageButtonsVisibilityStyle: false,
                         inputBoxMaxWidthStyle: "94",
                         textColorUserStyle: "#FFFFFF",
                         textColorNonUserStyle: "#FFFFFF",

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -7,7 +7,6 @@ export interface Settings {
     inputBoxMaxWidthStyle: string;
     textColorUserStyle: string;
     textColorNonUserStyle: string;
-    messageButtonsVisibilityStyle: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -19,5 +18,4 @@ export const defaultSettings: Settings = {
     inputBoxMaxWidthStyle: "94",
     textColorUserStyle: "#FFFFFF",
     textColorNonUserStyle: "#FFFFFF",
-    messageButtonsVisibilityStyle: true,
 };

--- a/src/shared/utils/__tests__/stylingFunctions.test.ts
+++ b/src/shared/utils/__tests__/stylingFunctions.test.ts
@@ -6,13 +6,13 @@ describe("buildCss", () => {
         const css = buildCss(defaultSettings);
 
         expect(css).toContain(
-            `max-width: ${defaultSettings.messageMaxWidthStyle}%`,
+            `max-width: ${defaultSettings.messageMaxWidthStyle}% !important`,
         );
         expect(css).toContain(
-            `padding: ${defaultSettings.messagePaddingStyle}px`,
+            `padding: ${defaultSettings.messagePaddingStyle}px !important`,
         );
         expect(css).toContain(
-            `border-radius: ${defaultSettings.messageBorderRadiusStyle}px`,
+            `border-radius: ${defaultSettings.messageBorderRadiusStyle}px !important`,
         );
         expect(css).toContain(
             `background-color: ${defaultSettings.messageColorUserStyle} !important`,
@@ -20,17 +20,12 @@ describe("buildCss", () => {
         expect(css).toContain(
             `background-color: ${defaultSettings.messageColorNonUserStyle} !important`,
         );
-        expect(css).toContain(`visibility: unset`);
-    });
-
-    it("applies messageButtonsVisibilityStyle false", () => {
-        const settings: Settings = {
-            ...defaultSettings,
-            messageButtonsVisibilityStyle: false,
-        };
-
-        expect(buildCss(settings)).toContain("visibility: invisible");
-        expect(buildCss(settings)).not.toContain("visibility: unset");
+        expect(css).toContain('[data-turn="user"] .user-message-bubble-color');
+        expect(css).toContain(
+            '[data-turn="assistant"] [data-message-author-role="assistant"]',
+        );
+        expect(css).not.toContain(":nth-child(odd) > * > *");
+        expect(css).not.toContain("visibility:");
     });
 
     it("is deterministic for the same settings object", () => {
@@ -63,9 +58,15 @@ describe("buildCss", () => {
     it("includes fixed helper styles", () => {
         const css = buildCss(defaultSettings);
 
+        expect(css).toContain(
+            '[data-testid^="conversation-turn-"] [data-conversation-screenshot-content]',
+        );
+        expect(css).toContain("#thread-bottom > div > div > div > div");
+        expect(css).toContain("max-width: none !important");
         expect(css).toContain("html.light #composer-submit-button");
-        expect(css).toContain("background-color: unset");
-        expect(css).toContain("display: block !important");
+        expect(css).not.toContain(".bg-token-message-surface");
+        expect(css).not.toContain(".bg-token-main-surface-tertiary");
+        expect(css).not.toContain('main > [role="presentation"]');
     });
 
     it("keeps updateStyles as a buildCss alias", () => {

--- a/src/shared/utils/stylingFunctions.ts
+++ b/src/shared/utils/stylingFunctions.ts
@@ -2,60 +2,50 @@ import { Settings } from "@src/shared/settings";
 import { UpdateStylesMessage } from "@src/shared/messaging";
 
 const messageBubbles = '[data-testid^="conversation-turn-"]';
+const userTurns = '[data-turn="user"]';
+const assistantTurns = '[data-turn="assistant"]';
+const userBubble = `${userTurns} .user-message-bubble-color`;
+const assistantMessage = `${assistantTurns} [data-message-author-role="assistant"]`;
 
 const fixedStyles = `
+    /* Remove ChatGPT's shared 40/48rem cap while preserving responsive gutters. */
+    ${messageBubbles} [data-conversation-screenshot-content],
+    #thread-bottom > div > div > div > div {
+        width: 100% !important;
+        max-width: none !important;
+    }
     ${messageBubbles} > * > * > *:nth-child(2) {
         width: 100%;
         max-width: calc(100% - 72px);
     }
     html.light #composer-submit-button { color:white }
-    ${messageBubbles} .bg-token-message-surface {
-        background-color: unset;
-    }
-    ${messageBubbles} .hidden {
-        display: block !important;
-    }
-    ${messageBubbles} .bg-token-message-surface {
-        max-width: calc(100% - 40px);
-        width: calc(100% - 40px);
-    }
-    ${messageBubbles} .bg-token-main-surface-tertiary {
-        background: transparent;
-    }
-    main > [role="presentation"] > div:nth-child(2) > div > div {
-        padding-left: 0;
-    }
-    main > [role="presentation"] > div:nth-child(2) > div > div > div {
-        max-width: unset;
-    }
 `;
 
 const buildDynamicStyles = (settings: Settings): string => {
-    const buttonVisibility = settings.messageButtonsVisibilityStyle
-        ? "unset"
-        : "invisible";
-
     return `
-            ${messageBubbles} > * > div { max-width: ${settings.messageMaxWidthStyle}% }
-          ${messageBubbles} > * > div { padding: ${settings.messagePaddingStyle}px; }
-          ${messageBubbles} > * > div { border-radius: ${settings.messageBorderRadiusStyle}px; }
+          ${userBubble}, ${assistantMessage} {
+            max-width: ${settings.messageMaxWidthStyle}% !important;
+            padding: ${settings.messagePaddingStyle}px !important;
+            border-radius: ${settings.messageBorderRadiusStyle}px !important;
+          }
           form {
             max-width: ${settings.inputBoxMaxWidthStyle}% !important;
             margin: auto !important;
             min-width: 300px
         }
-          :nth-child(odd) .bg-token-message-surface { color: ${settings.textColorUserStyle}}
-            ${messageBubbles}:nth-child(even) {
+          ${userBubble} {
+            color: ${settings.textColorUserStyle};
+            background-color: ${settings.messageColorUserStyle} !important;
+          }
+            ${assistantTurns} {
                 div > div > div:nth-child(2) > div, p, ul, li, strong, p > code, ul code, li::before, h1, h2, h3, h4 {
                     color: ${settings.textColorNonUserStyle};}}
-          ${messageBubbles} button { visibility: ${buttonVisibility} }
-          ${messageBubbles}:nth-child(odd) > * > * { background-color: ${settings.messageColorUserStyle} !important }
           ${messageBubbles} textarea {
             padding: 3px;
             background-color: rgba(0, 0, 0, 0.4);;
             border-radius: 5px
         }
-          ${messageBubbles}:nth-child(even) > * > * { background-color: ${settings.messageColorNonUserStyle} !important }
+          ${assistantMessage} { background-color: ${settings.messageColorNonUserStyle} !important }
         `;
 };
 


### PR DESCRIPTION
- Replace brittle profile/history selectors with accounts-profile-button and #history a[href^="/c/"]
- Skip the inert collapsed-rail profile duplicate when opening the account menu
- Rewrite delete-all as Profile → Settings → Data controls → Delete all → Confirm
- Harden Radix control activation (pointer + mouse + native click) and scope Settings dialog selectors
- Mark composer-submit as optional/conditional; reload the ChatGPT tab after successful delete-all
- Update selector health-check probes, tests, and DOM docs for the new flow

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
