### PR TITLE
Revamp UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@
 -   Removed an unused content-script handshake message
 -   Delete-all now awaits the content-script result and uses a hostname-based ChatGPT tab check
 -   Removed unused HomeMenu / MiscEditor / HomeButton multi-page shell; popup is MessageEditor-only
--   Simplified Header (title only; no vestigial Back / page state)
+-   Redesigned the popup with semantic light/dark theme tokens that follow the operating-system color preference
+-   Modernized slider, color-card, action-button, and delete-all styling while retaining the existing live-preview and save/cancel behavior
+-   Added a compact popup header using the existing extension icon and a theme-aware close control
+-   Improved disabled action states so controls remain visible instead of disappearing
 -   Standardized extension messaging on typed `chrome.*` contracts; removed `webextension-polyfill`
 -   Removed unused popup handshakes and the unused `SETTINGS_CHANGED` storage broadcast
 -   Hardened live-preview tab messaging against missing tabs / `runtime.lastError`

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Chrome Extension (built with TypeScript + React)</title>
+        <title>ChatGPT Styler</title>
     </head>
 
     <body>

--- a/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
+++ b/src/components/deleteAllChatsButton/DeleteAllChatsButton.tsx
@@ -143,7 +143,10 @@ export function DeleteAllChatsButton(): JSX.Element {
                         No
                     </button>
                 </div>
-                <p id="delete-all-confirm-label" className="text-base">
+                <p
+                    id="delete-all-confirm-label"
+                    className="text-sm text-ink-muted"
+                >
                     Are you sure?
                 </p>
             </div>

--- a/src/components/deleteAllChatsButton/__tests__/__snapshots__/deleteAllChatsButton.test.tsx.snap
+++ b/src/components/deleteAllChatsButton/__tests__/__snapshots__/deleteAllChatsButton.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`DeleteAllChatsButton should render the initial button 1`] = `
       </button>
     </div>
     <p
-      className="text-base"
+      className="text-sm text-ink-muted"
       id="delete-all-confirm-label"
     >
       Are you sure?

--- a/src/components/deleteAllChatsButton/styles.module.css
+++ b/src/components/deleteAllChatsButton/styles.module.css
@@ -1,62 +1,79 @@
 button.bigRedBtn {
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply font-medium;
     @apply text-sm;
-    @apply text-white;
     @apply w-full;
     @apply rounded-md;
-    @apply bg-red-700;
-    @apply grid;
-    @apply hover:bg-red-800;
-    @apply active:shadow-lg;
-    @apply active:shadow-red-400/50;
-    @apply disabled:bg-red-800/50;
-    @apply disabled:pointer-events-none;
+    @apply border;
+    @apply border-danger;
+    @apply text-danger;
+    @apply bg-surface-raised;
+    @apply hover:bg-danger;
+    @apply hover:text-danger-contrast;
+    @apply focus:outline-none;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-danger;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply duration-200;
 }
 
 button.yesBtn {
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply font-medium;
     @apply text-sm;
-    @apply text-white;
     @apply w-full;
     @apply rounded-md;
-    @apply bg-green-700;
-    @apply hover:bg-green-800;
-    @apply active:shadow-lg;
-    @apply active:shadow-green-400/50;
-    @apply disabled:bg-green-800/50;
+    @apply border;
+    @apply border-transparent;
+    @apply text-accent-contrast;
+    @apply bg-accent;
+    @apply hover:opacity-90;
+    @apply focus:outline-none;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-accent;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply duration-200;
 }
 
 button.noBtn {
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply font-medium;
     @apply text-sm;
-    @apply text-white;
     @apply w-full;
     @apply rounded-md;
-    @apply bg-red-700;
-    @apply hover:bg-red-800;
-    @apply active:shadow-lg;
-    @apply active:shadow-red-400/50;
-    @apply disabled:bg-red-800/50;
+    @apply border;
+    @apply border-edge;
+    @apply text-ink;
+    @apply bg-surface-raised;
+    @apply hover:bg-surface;
+    @apply focus:outline-none;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-accent;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply duration-200;
 }
 
 .errorMsg {
     @apply py-2;
-    @apply text-base;
+    @apply text-sm;
     @apply font-medium;
-    @apply text-red-600;
+    @apply text-danger;
     @apply text-center;
 }
 
 .successMsg {
     @apply py-2;
-    @apply text-base;
+    @apply text-sm;
     @apply font-medium;
-    @apply text-green-600;
+    @apply text-success;
     @apply text-center;
 }

--- a/src/components/formButtons/styles.module.css
+++ b/src/components/formButtons/styles.module.css
@@ -2,7 +2,7 @@ button.btn {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply border;
     @apply border-transparent;
@@ -10,24 +10,24 @@ button.btn {
     @apply font-medium;
     @apply whitespace-nowrap;
     @apply rounded-md;
-    @apply shadow-sm;
-    @apply text-white;
-    @apply bg-green-600;
-    @apply hover:bg-green-700;
+    @apply text-accent-contrast;
+    @apply bg-accent;
+    @apply hover:opacity-90;
     @apply focus:outline-none;
-    @apply focus:ring-2;
-    @apply focus:ring-offset-2;
-    @apply focus:ring-green-500;
-    @apply disabled:bg-green-600/0;
-    @apply disabled:text-transparent;
-    @apply disabled:shadow-none;
-    @apply duration-300;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-accent;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply disabled:hover:opacity-40;
+    @apply duration-200;
 }
+
 button.btnRed {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply border;
     @apply border-transparent;
@@ -35,41 +35,39 @@ button.btnRed {
     @apply font-medium;
     @apply whitespace-nowrap;
     @apply rounded-md;
-    @apply shadow-sm;
-    @apply text-white;
-    @apply bg-red-600;
-    @apply hover:bg-red-700;
+    @apply text-danger-contrast;
+    @apply bg-danger;
+    @apply hover:opacity-90;
     @apply focus:outline-none;
-    @apply focus:ring-2;
-    @apply focus:ring-offset-2;
-    @apply focus:ring-red-500;
-    @apply disabled:bg-red-600/0;
-    @apply disabled:text-transparent;
-    @apply disabled:shadow-none;
-    @apply duration-300;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-danger;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply disabled:hover:opacity-40;
+    @apply duration-200;
 }
 
 button.btnGrey {
     @apply inline-flex;
     @apply items-center;
     @apply justify-center;
-    @apply px-4;
+    @apply px-3;
     @apply py-2;
     @apply border;
-    @apply border-transparent;
+    @apply border-edge;
     @apply text-sm;
     @apply font-medium;
     @apply whitespace-nowrap;
     @apply rounded-md;
-    @apply shadow-sm;
-    @apply text-white;
-    @apply bg-gray-400;
-    @apply hover:bg-gray-500;
+    @apply text-ink;
+    @apply bg-surface-raised;
+    @apply hover:bg-surface;
     @apply focus:outline-none;
-    @apply focus:ring-2;
-    @apply focus:ring-offset-2;
-    @apply focus:bg-gray-300;
-    @apply disabled:bg-gray-400/0;
-    @apply disabled:text-transparent;
-    @apply duration-300;
+    @apply focus-visible:ring-2;
+    @apply focus-visible:ring-offset-2;
+    @apply focus-visible:ring-accent;
+    @apply disabled:opacity-40;
+    @apply disabled:cursor-not-allowed;
+    @apply duration-200;
 }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,8 +2,39 @@ import React from "react";
 
 export function Header(): JSX.Element {
     return (
-        <div className="p-3 text-center relative">
-            <h1 className="text-lg">ChatGPT Styler</h1>
-        </div>
+        <header className="px-3 pt-3 pb-2 border-b border-edge">
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5">
+                    <h1 className="text-base font-semibold tracking-tight text-ink">
+                        ChatGPT Styler
+                    </h1>
+                    <img
+                        src="icon-128.png"
+                        alt=""
+                        aria-hidden="true"
+                        className="w-6 h-6"
+                    />
+                </div>
+                <button
+                    type="button"
+                    aria-label="Close popup"
+                    className="w-6 h-6 flex items-center justify-center rounded-md text-ink hover:bg-surface-raised focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    onClick={() => window.close()}
+                >
+                    <svg
+                        aria-hidden="true"
+                        className="w-3.5 h-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                    >
+                        <line x1="5" y1="5" x2="19" y2="19" />
+                        <line x1="19" y1="5" x2="5" y2="19" />
+                    </svg>
+                </button>
+            </div>
+        </header>
     );
 }

--- a/src/components/header/__tests__/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__tests__/__snapshots__/header.test.tsx.snap
@@ -1,13 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component renders 1`] = `
-<div
-  className="p-3 text-center relative"
+<header
+  className="px-3 pt-3 pb-2 border-b border-edge"
 >
-  <h1
-    className="text-lg"
+  <div
+    className="flex items-center justify-between gap-2"
   >
-    ChatGPT Styler
-  </h1>
-</div>
+    <div
+      className="flex items-center gap-1.5"
+    >
+      <h1
+        className="text-base font-semibold tracking-tight text-ink"
+      >
+        ChatGPT Styler
+      </h1>
+      <img
+        alt=""
+        aria-hidden="true"
+        className="w-6 h-6"
+        src="icon-128.png"
+      />
+    </div>
+    <button
+      aria-label="Close popup"
+      className="w-6 h-6 flex items-center justify-center rounded-md text-ink hover:bg-surface-raised focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="w-3.5 h-3.5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="3"
+        viewBox="0 0 24 24"
+      >
+        <line
+          x1="5"
+          x2="19"
+          y1="5"
+          y2="19"
+        />
+        <line
+          x1="19"
+          x2="5"
+          y1="5"
+          y2="19"
+        />
+      </svg>
+    </button>
+  </div>
+</header>
 `;

--- a/src/components/selectorHealthCheck/SelectorHealthCheck.tsx
+++ b/src/components/selectorHealthCheck/SelectorHealthCheck.tsx
@@ -86,23 +86,23 @@ export function SelectorHealthCheck(): JSX.Element | null {
     };
 
     return (
-        <div className="grid gap-2 border border-dashed border-gray-500 rounded-md p-2">
+        <div className="grid gap-2 border border-dashed border-edge rounded-md p-2 bg-surface-raised">
             <button
                 type="button"
-                className="w-full px-3 py-2 text-sm font-medium text-white bg-indigo-700 rounded-md hover:bg-indigo-800 disabled:opacity-50"
+                className="w-full px-3 py-2 text-sm font-medium text-accent-contrast bg-accent rounded-md hover:opacity-90 disabled:opacity-40"
                 disabled={isLoading}
                 onClick={runCheck}
             >
                 {isLoading ? "Checking selectors…" : "Check ChatGPT Selectors"}
             </button>
             {error && (
-                <p role="status" className="text-sm text-red-700 text-center">
+                <p role="status" className="text-sm text-danger text-center">
                     {error}
                 </p>
             )}
             {report && (
-                <div className="text-xs text-gray-800 grid gap-1">
-                    <p className="font-medium">
+                <div className="text-xs text-ink grid gap-1">
+                    <p className="font-medium text-ink-muted">
                         Required {report.requiredOk} ok / {report.requiredFail}{" "}
                         fail · optional present {report.optionalPresent}
                     </p>
@@ -116,7 +116,7 @@ export function SelectorHealthCheck(): JSX.Element | null {
                     </ul>
                     <button
                         type="button"
-                        className="w-full mt-1 px-3 py-2 text-sm font-medium text-white bg-gray-700 rounded-md hover:bg-gray-800"
+                        className="w-full mt-1 px-3 py-2 text-sm font-medium text-ink bg-surface border border-edge rounded-md hover:bg-surface-raised"
                         onClick={copyResults}
                     >
                         {copyStatus === "copied" ? "Copied!" : "Copy Results"}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2,6 +2,92 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    --surface: #f7f7f8;
+    --surface-raised: #ffffff;
+    --border: #e5e5e5;
+    --text: #0d0d0d;
+    --text-muted: #6b6b6b;
+    --accent: #0d0d0d;
+    --accent-contrast: #ffffff;
+    --danger: #c43c3c;
+    --danger-contrast: #ffffff;
+    --success: #1f7a4c;
+    --track: #d9d9d9;
+    --thumb: #0d0d0d;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --surface: #212121;
+        --surface-raised: #2f2f2f;
+        --border: #444444;
+        --text: #ececec;
+        --text-muted: #a0a0a0;
+        --accent: #ececec;
+        --accent-contrast: #0d0d0d;
+        --danger: #ef6868;
+        --danger-contrast: #1a1a1a;
+        --success: #3db87a;
+        --track: #4a4a4a;
+        --thumb: #ececec;
+    }
+}
+
 body {
-    @apply bg-gray-200;
+    background-color: var(--surface);
+    color: var(--text);
+}
+
+/* Visible range sliders (native styling Tailwind can't express) */
+input[type="range"].control-range {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 1.25rem;
+    background: transparent;
+    cursor: pointer;
+}
+
+input[type="range"].control-range:focus {
+    outline: none;
+}
+
+input[type="range"].control-range:focus-visible::-webkit-slider-thumb {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+input[type="range"].control-range:focus-visible::-moz-range-thumb {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+input[type="range"].control-range::-webkit-slider-runnable-track {
+    height: 0.25rem;
+    border-radius: 9999px;
+    background: var(--track);
+}
+
+input[type="range"].control-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 0.875rem;
+    height: 0.875rem;
+    margin-top: -0.3125rem;
+    border-radius: 9999px;
+    background: var(--thumb);
+    border: none;
+}
+
+input[type="range"].control-range::-moz-range-track {
+    height: 0.25rem;
+    border-radius: 9999px;
+    background: var(--track);
+}
+
+input[type="range"].control-range::-moz-range-thumb {
+    width: 0.875rem;
+    height: 0.875rem;
+    border-radius: 9999px;
+    background: var(--thumb);
+    border: none;
 }

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -59,7 +59,6 @@ export function Popup(): JSX.Element {
         <div className={css.popupContainer}>
             <div className="w-full">
                 <Header />
-                <hr className="mb-2" />
                 <MessageEditor
                     liveSettings={liveSettings}
                     setLiveSettings={setLiveSettings}

--- a/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
+++ b/src/popup/__tests__/__snapshots__/test_popup.tsx.snap
@@ -7,274 +7,246 @@ exports[`component renders 1`] = `
   <div
     className="w-full"
   >
-    <div
-      className="p-3 text-center relative"
-    >
-      <h1
-        className="text-lg"
-      >
-        ChatGPT Styler
-      </h1>
-    </div>
-    <hr
-      className="mb-2"
-    />
-    <div
-      className="grid grid-cols-1 gap-y-3 px-3 pb-2 select-none animate-fade-in"
+    <header
+      className="px-3 pt-3 pb-2 border-b border-edge"
     >
       <div
-        className="grid grid-cols-1 gap-y-3 "
+        className="flex items-center justify-between gap-2"
       >
         <div
-          className="flex justify-between items-center"
+          className="flex items-center gap-1.5"
         >
-          <label
-            className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-            htmlFor="messageMaxWidthStyle"
-            style={
-              {
-                "backgroundColor": "rgba(145, 10, 103)",
-              }
-            }
+          <h1
+            className="text-base font-semibold tracking-tight text-ink"
           >
-            Message Width:
-          </label>
-           
-          <div
-            className="relative flex"
-          >
-            <input
-              className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-              id="messageMaxWidthStyle"
-              inputMode="numeric"
-              maxLength={3}
-              onChange={[Function]}
-              style={
-                {
-                  "backgroundColor": "rgba(145, 10, 103, 0.1)",
-                }
-              }
-              type="text"
-              value="95"
-            />
-            <input
-              aria-label="Message Width slider"
-              className="absolute w-full h-0.5 left-0 bottom-0"
-              id="messageMaxWidthStyle-range"
-              max="100"
-              min="1"
-              onChange={[Function]}
-              step="1"
-              style={
-                {
-                  "accentColor": "rgba(145, 10, 103)",
-                }
-              }
-              type="range"
-              value="95"
-            />
-          </div>
-          <div
+            ChatGPT Styler
+          </h1>
+          <img
+            alt=""
             aria-hidden="true"
-            className="py-2 rounded-r-sm"
-            style={
-              {
-                "backgroundColor": "rgba(145, 10, 103, 0.1)",
-              }
-            }
+            className="w-6 h-6"
+            src="icon-128.png"
+          />
+        </div>
+        <button
+          aria-label="Close popup"
+          className="w-6 h-6 flex items-center justify-center rounded-md text-ink hover:bg-surface-raised focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="w-3.5 h-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth="3"
+            viewBox="0 0 24 24"
           >
-            %
+            <line
+              x1="5"
+              x2="19"
+              y1="5"
+              y2="19"
+            />
+            <line
+              x1="19"
+              x2="5"
+              y1="5"
+              y2="19"
+            />
+          </svg>
+        </button>
+      </div>
+    </header>
+    <div
+      className="grid grid-cols-1 gap-y-3 px-3 pt-3 pb-3 select-none animate-fade-in"
+    >
+      <div
+        className="grid grid-cols-1 gap-y-3"
+      >
+        <div
+          className="grid gap-1.5"
+        >
+          <div
+            className="flex items-center justify-between gap-2"
+          >
+            <label
+              className="text-sm font-medium text-ink"
+              htmlFor="messageMaxWidthStyle"
+            >
+              Message Width
+            </label>
+            <div
+              className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+            >
+              <input
+                className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+                id="messageMaxWidthStyle"
+                inputMode="numeric"
+                maxLength={3}
+                onChange={[Function]}
+                type="text"
+                value="95"
+              />
+              <span
+                aria-hidden="true"
+                className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+              >
+                %
+              </span>
+            </div>
           </div>
+          <input
+            aria-label="Message Width slider"
+            className="control-range"
+            id="messageMaxWidthStyle-range"
+            max="100"
+            min="1"
+            onChange={[Function]}
+            step="1"
+            type="range"
+            value="95"
+          />
         </div>
         <div
-          className="flex justify-between items-center"
+          className="grid gap-1.5"
         >
-          <label
-            className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-            htmlFor="messagePaddingStyle"
-            style={
-              {
-                "backgroundColor": "rgba(114, 4, 85)",
-              }
-            }
-          >
-            Message Padding:
-          </label>
-           
           <div
-            className="relative flex"
+            className="flex items-center justify-between gap-2"
           >
-            <input
-              className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-              id="messagePaddingStyle"
-              inputMode="numeric"
-              maxLength={3}
-              onChange={[Function]}
-              style={
-                {
-                  "backgroundColor": "rgba(114, 4, 85, 0.1)",
-                }
-              }
-              type="text"
-              value="10"
-            />
-            <input
-              aria-label="Message Padding slider"
-              className="absolute w-full h-0.5 left-0 bottom-0"
-              id="messagePaddingStyle-range"
-              max="100"
-              min="1"
-              onChange={[Function]}
-              step="1"
-              style={
-                {
-                  "accentColor": "rgba(114, 4, 85)",
-                }
-              }
-              type="range"
-              value="10"
-            />
+            <label
+              className="text-sm font-medium text-ink"
+              htmlFor="messagePaddingStyle"
+            >
+              Message Padding
+            </label>
+            <div
+              className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+            >
+              <input
+                className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+                id="messagePaddingStyle"
+                inputMode="numeric"
+                maxLength={3}
+                onChange={[Function]}
+                type="text"
+                value="10"
+              />
+              <span
+                aria-hidden="true"
+                className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+              >
+                px
+              </span>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            className="py-2 rounded-r-sm"
-            style={
-              {
-                "backgroundColor": "rgba(114, 4, 85, 0.1)",
-              }
-            }
-          >
-            px
-          </div>
+          <input
+            aria-label="Message Padding slider"
+            className="control-range"
+            id="messagePaddingStyle-range"
+            max="100"
+            min="1"
+            onChange={[Function]}
+            step="1"
+            type="range"
+            value="10"
+          />
         </div>
         <div
-          className="flex justify-between items-center"
+          className="grid gap-1.5"
         >
-          <label
-            className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-            htmlFor="messageBorderRadiusStyle"
-            style={
-              {
-                "backgroundColor": "rgba(60, 7, 83)",
-              }
-            }
-          >
-            Message Border:
-          </label>
-           
           <div
-            className="relative flex"
+            className="flex items-center justify-between gap-2"
           >
-            <input
-              className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-              id="messageBorderRadiusStyle"
-              inputMode="numeric"
-              maxLength={3}
-              onChange={[Function]}
-              style={
-                {
-                  "backgroundColor": "rgba(60, 7, 83, 0.1)",
-                }
-              }
-              type="text"
-              value="5"
-            />
-            <input
-              aria-label="Message Border slider"
-              className="absolute w-full h-0.5 left-0 bottom-0"
-              id="messageBorderRadiusStyle-range"
-              max="100"
-              min="1"
-              onChange={[Function]}
-              step="1"
-              style={
-                {
-                  "accentColor": "rgba(60, 7, 83)",
-                }
-              }
-              type="range"
-              value="5"
-            />
+            <label
+              className="text-sm font-medium text-ink"
+              htmlFor="messageBorderRadiusStyle"
+            >
+              Message Border
+            </label>
+            <div
+              className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+            >
+              <input
+                className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+                id="messageBorderRadiusStyle"
+                inputMode="numeric"
+                maxLength={3}
+                onChange={[Function]}
+                type="text"
+                value="5"
+              />
+              <span
+                aria-hidden="true"
+                className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+              >
+                px
+              </span>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            className="py-2 rounded-r-sm"
-            style={
-              {
-                "backgroundColor": "rgba(60, 7, 83, 0.1)",
-              }
-            }
-          >
-            px
-          </div>
+          <input
+            aria-label="Message Border slider"
+            className="control-range"
+            id="messageBorderRadiusStyle-range"
+            max="100"
+            min="1"
+            onChange={[Function]}
+            step="1"
+            type="range"
+            value="5"
+          />
         </div>
         <div
-          className="flex justify-between items-center"
+          className="grid gap-1.5"
         >
-          <label
-            className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-            htmlFor="inputBoxMaxWidthStyle"
-            style={
-              {
-                "backgroundColor": "rgba(3, 6, 55)",
-              }
-            }
-          >
-            Input Box Width:
-          </label>
-           
           <div
-            className="relative flex"
+            className="flex items-center justify-between gap-2"
           >
-            <input
-              className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-              id="inputBoxMaxWidthStyle"
-              inputMode="numeric"
-              maxLength={3}
-              onChange={[Function]}
-              style={
-                {
-                  "backgroundColor": "rgba(3, 6, 55, 0.1)",
-                }
-              }
-              type="text"
-              value="94"
-            />
-            <input
-              aria-label="Input Box Width slider"
-              className="absolute w-full h-0.5 left-0 bottom-0"
-              id="inputBoxMaxWidthStyle-range"
-              max="100"
-              min="1"
-              onChange={[Function]}
-              step="1"
-              style={
-                {
-                  "accentColor": "rgba(3, 6, 55)",
-                }
-              }
-              type="range"
-              value="94"
-            />
+            <label
+              className="text-sm font-medium text-ink"
+              htmlFor="inputBoxMaxWidthStyle"
+            >
+              Input Box Width
+            </label>
+            <div
+              className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+            >
+              <input
+                className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+                id="inputBoxMaxWidthStyle"
+                inputMode="numeric"
+                maxLength={3}
+                onChange={[Function]}
+                type="text"
+                value="94"
+              />
+              <span
+                aria-hidden="true"
+                className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+              >
+                %
+              </span>
+            </div>
           </div>
-          <div
-            aria-hidden="true"
-            className="py-2 rounded-r-sm"
-            style={
-              {
-                "backgroundColor": "rgba(3, 6, 55, 0.1)",
-              }
-            }
-          >
-            %
-          </div>
+          <input
+            aria-label="Input Box Width slider"
+            className="control-range"
+            id="inputBoxMaxWidthStyle-range"
+            max="100"
+            min="1"
+            onChange={[Function]}
+            step="1"
+            type="range"
+            value="94"
+          />
         </div>
       </div>
       <div
         className="grid grid-cols-2 gap-2 place-items-center w-full"
       >
         <fieldset
-          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+          className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
         >
           <legend
             className="sr-only"
@@ -283,7 +255,7 @@ exports[`component renders 1`] = `
           </legend>
           <div
             aria-hidden="true"
-            className="text-center p-1 w-24 rounded-md"
+            className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
             style={
               {
                 "backgroundColor": "#0084FF",
@@ -294,11 +266,11 @@ exports[`component renders 1`] = `
             User Color
           </div>
           <div
-            className="grid grid-cols-2 gap-1 w-full text-white"
+            className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
           >
             <input
               aria-label="User background color"
-              className="text-center w-full rounded-md h-8"
+              className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
               id="messageColorUserStyle"
               onChange={[Function]}
               type="color"
@@ -306,26 +278,26 @@ exports[`component renders 1`] = `
             />
             <input
               aria-label="User text color"
-              className="text-center w-full rounded-md h-8"
+              className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
               id="textColorUserStyle"
               onChange={[Function]}
               type="color"
               value="#FFFFFF"
             />
             <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              className="text-center font-medium p-0 m-0"
             >
               BG
             </span>
             <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              className="text-center font-medium p-0 m-0"
             >
               Text
             </span>
           </div>
         </fieldset>
         <fieldset
-          className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+          className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
         >
           <legend
             className="sr-only"
@@ -334,7 +306,7 @@ exports[`component renders 1`] = `
           </legend>
           <div
             aria-hidden="true"
-            className="text-center p-1 w-24 rounded-md"
+            className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
             style={
               {
                 "backgroundColor": "#333333",
@@ -345,11 +317,11 @@ exports[`component renders 1`] = `
             ChatGPT Color
           </div>
           <div
-            className="grid grid-cols-2 gap-1 w-full text-white"
+            className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
           >
             <input
               aria-label="ChatGPT background color"
-              className="text-center w-full rounded-md h-8"
+              className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
               id="messageColorNonUserStyle"
               onChange={[Function]}
               type="color"
@@ -357,19 +329,19 @@ exports[`component renders 1`] = `
             />
             <input
               aria-label="ChatGPT text color"
-              className="text-center w-full rounded-md h-8"
+              className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
               id="textColorNonUserStyle"
               onChange={[Function]}
               type="color"
               value="#FFFFFF"
             />
             <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              className="text-center font-medium p-0 m-0"
             >
               BG
             </span>
             <span
-              className="rounded-md font-medium text-center p-0 m-0"
+              className="text-center font-medium p-0 m-0"
             >
               Text
             </span>
@@ -443,7 +415,7 @@ exports[`component renders 1`] = `
             </button>
           </div>
           <p
-            className="text-base"
+            className="text-sm text-ink-muted"
             id="delete-all-confirm-label"
           >
             Are you sure?

--- a/src/popup/styles.module.css
+++ b/src/popup/styles.module.css
@@ -1,5 +1,7 @@
 .popupContainer {
-    min-width: 300px;
+    min-width: 340px;
     min-height: 300px;
     display: flex;
+    background-color: var(--surface);
+    color: var(--text);
 }

--- a/src/popup/views/messageEditor/MessageEditor.tsx
+++ b/src/popup/views/messageEditor/MessageEditor.tsx
@@ -30,7 +30,7 @@ export function MessageEditor({
 
     return (
         <div
-            className={`grid grid-cols-1 gap-y-3 px-3 pb-2 select-none ${
+            className={`grid grid-cols-1 gap-y-3 px-3 pt-3 pb-3 select-none ${
                 !isEditing ? "animate-fade-in" : ""
             }`}
         >

--- a/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
+++ b/src/popup/views/messageEditor/__tests__/__snapshots__/messageEditor.test.tsx.snap
@@ -2,261 +2,193 @@
 
 exports[`MessageEditor Component renders correctly 1`] = `
 <div
-  className="grid grid-cols-1 gap-y-3 px-3 pb-2 select-none animate-fade-in"
+  className="grid grid-cols-1 gap-y-3 px-3 pt-3 pb-3 select-none animate-fade-in"
 >
   <div
-    className="grid grid-cols-1 gap-y-3 "
+    className="grid grid-cols-1 gap-y-3"
   >
     <div
-      className="flex justify-between items-center"
+      className="grid gap-1.5"
     >
-      <label
-        className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-        htmlFor="messageMaxWidthStyle"
-        style={
-          {
-            "backgroundColor": "rgba(145, 10, 103)",
-          }
-        }
-      >
-        Message Width:
-      </label>
-       
       <div
-        className="relative flex"
+        className="flex items-center justify-between gap-2"
       >
-        <input
-          className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-          id="messageMaxWidthStyle"
-          inputMode="numeric"
-          maxLength={3}
-          onChange={[Function]}
-          style={
-            {
-              "backgroundColor": "rgba(145, 10, 103, 0.1)",
-            }
-          }
-          type="text"
-          value=""
-        />
-        <input
-          aria-label="Message Width slider"
-          className="absolute w-full h-0.5 left-0 bottom-0"
-          id="messageMaxWidthStyle-range"
-          max="100"
-          min="1"
-          onChange={[Function]}
-          step="1"
-          style={
-            {
-              "accentColor": "rgba(145, 10, 103)",
-            }
-          }
-          type="range"
-          value=""
-        />
+        <label
+          className="text-sm font-medium text-ink"
+          htmlFor="messageMaxWidthStyle"
+        >
+          Message Width
+        </label>
+        <div
+          className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+        >
+          <input
+            className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+            id="messageMaxWidthStyle"
+            inputMode="numeric"
+            maxLength={3}
+            onChange={[Function]}
+            type="text"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+          >
+            %
+          </span>
+        </div>
       </div>
-      <div
-        aria-hidden="true"
-        className="py-2 rounded-r-sm"
-        style={
-          {
-            "backgroundColor": "rgba(145, 10, 103, 0.1)",
-          }
-        }
-      >
-        %
-      </div>
+      <input
+        aria-label="Message Width slider"
+        className="control-range"
+        id="messageMaxWidthStyle-range"
+        max="100"
+        min="1"
+        onChange={[Function]}
+        step="1"
+        type="range"
+        value=""
+      />
     </div>
     <div
-      className="flex justify-between items-center"
+      className="grid gap-1.5"
     >
-      <label
-        className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-        htmlFor="messagePaddingStyle"
-        style={
-          {
-            "backgroundColor": "rgba(114, 4, 85)",
-          }
-        }
-      >
-        Message Padding:
-      </label>
-       
       <div
-        className="relative flex"
+        className="flex items-center justify-between gap-2"
       >
-        <input
-          className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-          id="messagePaddingStyle"
-          inputMode="numeric"
-          maxLength={3}
-          onChange={[Function]}
-          style={
-            {
-              "backgroundColor": "rgba(114, 4, 85, 0.1)",
-            }
-          }
-          type="text"
-          value=""
-        />
-        <input
-          aria-label="Message Padding slider"
-          className="absolute w-full h-0.5 left-0 bottom-0"
-          id="messagePaddingStyle-range"
-          max="100"
-          min="1"
-          onChange={[Function]}
-          step="1"
-          style={
-            {
-              "accentColor": "rgba(114, 4, 85)",
-            }
-          }
-          type="range"
-          value=""
-        />
+        <label
+          className="text-sm font-medium text-ink"
+          htmlFor="messagePaddingStyle"
+        >
+          Message Padding
+        </label>
+        <div
+          className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+        >
+          <input
+            className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+            id="messagePaddingStyle"
+            inputMode="numeric"
+            maxLength={3}
+            onChange={[Function]}
+            type="text"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+          >
+            px
+          </span>
+        </div>
       </div>
-      <div
-        aria-hidden="true"
-        className="py-2 rounded-r-sm"
-        style={
-          {
-            "backgroundColor": "rgba(114, 4, 85, 0.1)",
-          }
-        }
-      >
-        px
-      </div>
+      <input
+        aria-label="Message Padding slider"
+        className="control-range"
+        id="messagePaddingStyle-range"
+        max="100"
+        min="1"
+        onChange={[Function]}
+        step="1"
+        type="range"
+        value=""
+      />
     </div>
     <div
-      className="flex justify-between items-center"
+      className="grid gap-1.5"
     >
-      <label
-        className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-        htmlFor="messageBorderRadiusStyle"
-        style={
-          {
-            "backgroundColor": "rgba(60, 7, 83)",
-          }
-        }
-      >
-        Message Border:
-      </label>
-       
       <div
-        className="relative flex"
+        className="flex items-center justify-between gap-2"
       >
-        <input
-          className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-          id="messageBorderRadiusStyle"
-          inputMode="numeric"
-          maxLength={3}
-          onChange={[Function]}
-          style={
-            {
-              "backgroundColor": "rgba(60, 7, 83, 0.1)",
-            }
-          }
-          type="text"
-          value=""
-        />
-        <input
-          aria-label="Message Border slider"
-          className="absolute w-full h-0.5 left-0 bottom-0"
-          id="messageBorderRadiusStyle-range"
-          max="100"
-          min="1"
-          onChange={[Function]}
-          step="1"
-          style={
-            {
-              "accentColor": "rgba(60, 7, 83)",
-            }
-          }
-          type="range"
-          value=""
-        />
+        <label
+          className="text-sm font-medium text-ink"
+          htmlFor="messageBorderRadiusStyle"
+        >
+          Message Border
+        </label>
+        <div
+          className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+        >
+          <input
+            className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+            id="messageBorderRadiusStyle"
+            inputMode="numeric"
+            maxLength={3}
+            onChange={[Function]}
+            type="text"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+          >
+            px
+          </span>
+        </div>
       </div>
-      <div
-        aria-hidden="true"
-        className="py-2 rounded-r-sm"
-        style={
-          {
-            "backgroundColor": "rgba(60, 7, 83, 0.1)",
-          }
-        }
-      >
-        px
-      </div>
+      <input
+        aria-label="Message Border slider"
+        className="control-range"
+        id="messageBorderRadiusStyle-range"
+        max="100"
+        min="1"
+        onChange={[Function]}
+        step="1"
+        type="range"
+        value=""
+      />
     </div>
     <div
-      className="flex justify-between items-center"
+      className="grid gap-1.5"
     >
-      <label
-        className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-        htmlFor="inputBoxMaxWidthStyle"
-        style={
-          {
-            "backgroundColor": "rgba(3, 6, 55)",
-          }
-        }
-      >
-        Input Box Width:
-      </label>
-       
       <div
-        className="relative flex"
+        className="flex items-center justify-between gap-2"
       >
-        <input
-          className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-          id="inputBoxMaxWidthStyle"
-          inputMode="numeric"
-          maxLength={3}
-          onChange={[Function]}
-          style={
-            {
-              "backgroundColor": "rgba(3, 6, 55, 0.1)",
-            }
-          }
-          type="text"
-          value=""
-        />
-        <input
-          aria-label="Input Box Width slider"
-          className="absolute w-full h-0.5 left-0 bottom-0"
-          id="inputBoxMaxWidthStyle-range"
-          max="100"
-          min="1"
-          onChange={[Function]}
-          step="1"
-          style={
-            {
-              "accentColor": "rgba(3, 6, 55)",
-            }
-          }
-          type="range"
-          value=""
-        />
+        <label
+          className="text-sm font-medium text-ink"
+          htmlFor="inputBoxMaxWidthStyle"
+        >
+          Input Box Width
+        </label>
+        <div
+          className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+        >
+          <input
+            className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+            id="inputBoxMaxWidthStyle"
+            inputMode="numeric"
+            maxLength={3}
+            onChange={[Function]}
+            type="text"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+          >
+            %
+          </span>
+        </div>
       </div>
-      <div
-        aria-hidden="true"
-        className="py-2 rounded-r-sm"
-        style={
-          {
-            "backgroundColor": "rgba(3, 6, 55, 0.1)",
-          }
-        }
-      >
-        %
-      </div>
+      <input
+        aria-label="Input Box Width slider"
+        className="control-range"
+        id="inputBoxMaxWidthStyle-range"
+        max="100"
+        min="1"
+        onChange={[Function]}
+        step="1"
+        type="range"
+        value=""
+      />
     </div>
   </div>
   <div
     className="grid grid-cols-2 gap-2 place-items-center w-full"
   >
     <fieldset
-      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+      className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
     >
       <legend
         className="sr-only"
@@ -265,7 +197,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
       </legend>
       <div
         aria-hidden="true"
-        className="text-center p-1 w-24 rounded-md"
+        className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
         style={
           {
             "backgroundColor": "",
@@ -276,11 +208,11 @@ exports[`MessageEditor Component renders correctly 1`] = `
         User Color
       </div>
       <div
-        className="grid grid-cols-2 gap-1 w-full text-white"
+        className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
       >
         <input
           aria-label="User background color"
-          className="text-center w-full rounded-md h-8"
+          className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
           id="messageColorUserStyle"
           onChange={[Function]}
           type="color"
@@ -288,26 +220,26 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
         <input
           aria-label="User text color"
-          className="text-center w-full rounded-md h-8"
+          className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
           id="textColorUserStyle"
           onChange={[Function]}
           type="color"
           value=""
         />
         <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          className="text-center font-medium p-0 m-0"
         >
           BG
         </span>
         <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          className="text-center font-medium p-0 m-0"
         >
           Text
         </span>
       </div>
     </fieldset>
     <fieldset
-      className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+      className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
     >
       <legend
         className="sr-only"
@@ -316,7 +248,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
       </legend>
       <div
         aria-hidden="true"
-        className="text-center p-1 w-24 rounded-md"
+        className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
         style={
           {
             "backgroundColor": "",
@@ -327,11 +259,11 @@ exports[`MessageEditor Component renders correctly 1`] = `
         ChatGPT Color
       </div>
       <div
-        className="grid grid-cols-2 gap-1 w-full text-white"
+        className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
       >
         <input
           aria-label="ChatGPT background color"
-          className="text-center w-full rounded-md h-8"
+          className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
           id="messageColorNonUserStyle"
           onChange={[Function]}
           type="color"
@@ -339,19 +271,19 @@ exports[`MessageEditor Component renders correctly 1`] = `
         />
         <input
           aria-label="ChatGPT text color"
-          className="text-center w-full rounded-md h-8"
+          className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
           id="textColorNonUserStyle"
           onChange={[Function]}
           type="color"
           value=""
         />
         <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          className="text-center font-medium p-0 m-0"
         >
           BG
         </span>
         <span
-          className="rounded-md font-medium text-center p-0 m-0"
+          className="text-center font-medium p-0 m-0"
         >
           Text
         </span>
@@ -425,7 +357,7 @@ exports[`MessageEditor Component renders correctly 1`] = `
         </button>
       </div>
       <p
-        className="text-base"
+        className="text-sm text-ink-muted"
         id="delete-all-confirm-label"
       >
         Are you sure?

--- a/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
+++ b/src/popup/views/messageEditor/components/colorControls/ColorControls.tsx
@@ -23,11 +23,11 @@ export function ColorControls({
         return (
             <fieldset
                 key={index}
-                className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+                className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
             >
                 <legend className="sr-only">{`${userType} color settings`}</legend>
                 <div
-                    className="text-center p-1 w-24 rounded-md"
+                    className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
                     aria-hidden="true"
                     style={{
                         backgroundColor:
@@ -49,7 +49,7 @@ export function ColorControls({
                 >
                     {`${userType} Color`}
                 </div>
-                <div className="grid grid-cols-2 gap-1 w-full text-white">
+                <div className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs">
                     {colorSettings.map((setting, settingIndex) =>
                         mapSettingInputs(
                             setting,
@@ -58,10 +58,8 @@ export function ColorControls({
                             userType,
                         ),
                     )}
-                    <span className="rounded-md font-medium text-center p-0 m-0">
-                        BG
-                    </span>
-                    <span className="rounded-md font-medium text-center p-0 m-0">
+                    <span className="text-center font-medium p-0 m-0">BG</span>
+                    <span className="text-center font-medium p-0 m-0">
                         Text
                     </span>
                 </div>
@@ -96,7 +94,7 @@ export function ColorControls({
         return (
             <input
                 key={index}
-                className="text-center w-full rounded-md h-8"
+                className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
                 type="color"
                 id={settingsKey}
                 aria-label={`${userType} ${channelLabel} color`}

--- a/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
+++ b/src/popup/views/messageEditor/components/colorControls/__tests__/__snapshots__/colorControls.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ColorControls component renders correctly 1`] = `
   className="grid grid-cols-2 gap-2 place-items-center w-full"
 >
   <fieldset
-    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+    className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
   >
     <legend
       className="sr-only"
@@ -14,7 +14,7 @@ exports[`ColorControls component renders correctly 1`] = `
     </legend>
     <div
       aria-hidden="true"
-      className="text-center p-1 w-24 rounded-md"
+      className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
       style={
         {
           "backgroundColor": "#386d9f",
@@ -25,11 +25,11 @@ exports[`ColorControls component renders correctly 1`] = `
       User Color
     </div>
     <div
-      className="grid grid-cols-2 gap-1 w-full text-white"
+      className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
     >
       <input
         aria-label="User background color"
-        className="text-center w-full rounded-md h-8"
+        className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
         id="messageColorUserStyle"
         onChange={[Function]}
         type="color"
@@ -37,26 +37,26 @@ exports[`ColorControls component renders correctly 1`] = `
       />
       <input
         aria-label="User text color"
-        className="text-center w-full rounded-md h-8"
+        className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
         id="textColorUserStyle"
         onChange={[Function]}
         type="color"
         value="#FFFFFF"
       />
       <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        className="text-center font-medium p-0 m-0"
       >
         BG
       </span>
       <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        className="text-center font-medium p-0 m-0"
       >
         Text
       </span>
     </div>
   </fieldset>
   <fieldset
-    className="flex flex-col justify-center items-center bg-violet-500 rounded-md p-3 gap-1 font-medium w-full border-0 m-0 min-w-0"
+    className="flex flex-col justify-center items-center bg-surface-raised border border-edge rounded-lg p-3 gap-2 font-medium w-full m-0 min-w-0"
   >
     <legend
       className="sr-only"
@@ -65,7 +65,7 @@ exports[`ColorControls component renders correctly 1`] = `
     </legend>
     <div
       aria-hidden="true"
-      className="text-center p-1 w-24 rounded-md"
+      className="text-center text-sm px-2 py-1.5 w-full rounded-md border border-edge"
       style={
         {
           "backgroundColor": "#333333",
@@ -76,11 +76,11 @@ exports[`ColorControls component renders correctly 1`] = `
       ChatGPT Color
     </div>
     <div
-      className="grid grid-cols-2 gap-1 w-full text-white"
+      className="grid grid-cols-2 gap-2 w-full text-ink-muted text-xs"
     >
       <input
         aria-label="ChatGPT background color"
-        className="text-center w-full rounded-md h-8"
+        className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
         id="messageColorNonUserStyle"
         onChange={[Function]}
         type="color"
@@ -88,19 +88,19 @@ exports[`ColorControls component renders correctly 1`] = `
       />
       <input
         aria-label="ChatGPT text color"
-        className="text-center w-full rounded-md h-8"
+        className="text-center w-full rounded-md h-8 border border-edge bg-surface cursor-pointer"
         id="textColorNonUserStyle"
         onChange={[Function]}
         type="color"
         value="#FFFFFF"
       />
       <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        className="text-center font-medium p-0 m-0"
       >
         BG
       </span>
       <span
-        className="rounded-md font-medium text-center p-0 m-0"
+        className="text-center font-medium p-0 m-0"
       >
         Text
       </span>

--- a/src/popup/views/messageEditor/components/messageSliderControls/MessageSliderControls.tsx
+++ b/src/popup/views/messageEditor/components/messageSliderControls/MessageSliderControls.tsx
@@ -8,53 +8,41 @@ export interface MessageSliderControlsProps {
     setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+type InputSetting = {
+    name: string;
+    id: keyof Settings;
+    valueType: "px" | "%";
+};
+
+const inputSettings: InputSetting[] = [
+    {
+        name: "Message Width",
+        id: "messageMaxWidthStyle",
+        valueType: "%",
+    },
+    {
+        name: "Message Padding",
+        id: "messagePaddingStyle",
+        valueType: "px",
+    },
+    {
+        name: "Message Border",
+        id: "messageBorderRadiusStyle",
+        valueType: "px",
+    },
+    {
+        name: "Input Box Width",
+        id: "inputBoxMaxWidthStyle",
+        valueType: "%",
+    },
+];
+
 export function MessageSliderControls({
     setLiveSettings,
     liveSettings,
     setIsEditing,
 }: MessageSliderControlsProps): JSX.Element {
-    // using this to create data we need so we can map through and have clean callback
-    class InputSetting {
-        name = "";
-        id: keyof Settings = "messageMaxWidthStyle";
-        valueType: "px" | "%" = "px";
-        bgColor = "";
-
-        constructor(settingsProperties: InputSetting) {
-            this.name = settingsProperties.name;
-            this.id = settingsProperties.id;
-            this.valueType = settingsProperties.valueType;
-            this.bgColor = settingsProperties.bgColor;
-        }
-    }
-    const inputSettings = [
-        new InputSetting({
-            name: "Message Width",
-            id: "messageMaxWidthStyle",
-            valueType: "%",
-            bgColor: "rgba(145, 10, 103",
-        }),
-        new InputSetting({
-            name: "Message Padding",
-            id: "messagePaddingStyle",
-            valueType: "px",
-            bgColor: "rgba(114, 4, 85",
-        }),
-        new InputSetting({
-            name: "Message Border",
-            id: "messageBorderRadiusStyle",
-            valueType: "px",
-            bgColor: "rgba(60, 7, 83",
-        }),
-        new InputSetting({
-            name: "Input Box Width",
-            id: "inputBoxMaxWidthStyle",
-            valueType: "%",
-            bgColor: "rgba(3, 6, 55",
-        }),
-    ];
-
-    const mapInputSettings = (setting: InputSetting, index: number) => {
+    const mapInputSettings = (setting: InputSetting) => {
         const rangeId = `${setting.id}-range`;
 
         const handleOnChange = (
@@ -74,56 +62,51 @@ export function MessageSliderControls({
                 sendMessageToTab(nextSettings);
             }
         };
+
         return (
-            <div className="flex justify-between items-center" key={index}>
-                <label
-                    htmlFor={setting.id}
-                    className={`basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2`}
-                    style={{
-                        backgroundColor: `${setting.bgColor})`,
-                    }}
-                >{`${setting.name}:`}</label>{" "}
-                <div className="relative flex">
-                    <input
-                        className={`outline-none px-2 py-2 w-full text-right rounded-l-sm `}
-                        type="text"
-                        maxLength={3}
-                        inputMode="numeric"
-                        style={{
-                            backgroundColor: `${setting.bgColor}, 0.1)`,
-                        }}
-                        value={liveSettings[setting.id].toString()}
-                        id={setting.id}
-                        onChange={(e) => handleOnChange(e, setting.id)}
-                    ></input>
-                    <input
-                        type="range"
-                        id={rangeId}
-                        min="1"
-                        max="100"
-                        value={liveSettings[setting.id].toString()}
-                        className="absolute w-full h-0.5 left-0 bottom-0"
-                        onChange={(e) => handleOnChange(e, setting.id)}
-                        step={"1"}
-                        style={{ accentColor: `${setting.bgColor})` }}
-                        aria-label={`${setting.name} slider`}
-                    ></input>
+            <div className="grid gap-1.5" key={setting.id}>
+                <div className="flex items-center justify-between gap-2">
+                    <label
+                        htmlFor={setting.id}
+                        className="text-sm font-medium text-ink"
+                    >
+                        {setting.name}
+                    </label>
+                    <div className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden">
+                        <input
+                            className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+                            type="text"
+                            maxLength={3}
+                            inputMode="numeric"
+                            value={liveSettings[setting.id].toString()}
+                            id={setting.id}
+                            onChange={(e) => handleOnChange(e, setting.id)}
+                        />
+                        <span
+                            className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+                            aria-hidden="true"
+                        >
+                            {setting.valueType}
+                        </span>
+                    </div>
                 </div>
-                <div
-                    className={`py-2 rounded-r-sm`}
-                    style={{
-                        backgroundColor: `${setting.bgColor}, 0.1)`,
-                    }}
-                    aria-hidden="true"
-                >
-                    {setting.valueType}
-                </div>
+                <input
+                    type="range"
+                    id={rangeId}
+                    min="1"
+                    max="100"
+                    value={liveSettings[setting.id].toString()}
+                    className="control-range"
+                    onChange={(e) => handleOnChange(e, setting.id)}
+                    step={"1"}
+                    aria-label={`${setting.name} slider`}
+                />
             </div>
         );
     };
 
     return (
-        <div className={`grid grid-cols-1 gap-y-3 `}>
+        <div className="grid grid-cols-1 gap-y-3">
             {inputSettings.map(mapInputSettings)}
         </div>
     );

--- a/src/popup/views/messageEditor/components/messageSliderControls/__tests__/__snapshots__/messageSliderControls.test.tsx.snap
+++ b/src/popup/views/messageEditor/components/messageSliderControls/__tests__/__snapshots__/messageSliderControls.test.tsx.snap
@@ -2,251 +2,183 @@
 
 exports[`MessageSliderControls component renders correctly 1`] = `
 <div
-  className="grid grid-cols-1 gap-y-3 "
+  className="grid grid-cols-1 gap-y-3"
 >
   <div
-    className="flex justify-between items-center"
+    className="grid gap-1.5"
   >
-    <label
-      className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-      htmlFor="messageMaxWidthStyle"
-      style={
-        {
-          "backgroundColor": "rgba(145, 10, 103)",
-        }
-      }
-    >
-      Message Width:
-    </label>
-     
     <div
-      className="relative flex"
+      className="flex items-center justify-between gap-2"
     >
-      <input
-        className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-        id="messageMaxWidthStyle"
-        inputMode="numeric"
-        maxLength={3}
-        onChange={[Function]}
-        style={
-          {
-            "backgroundColor": "rgba(145, 10, 103, 0.1)",
-          }
-        }
-        type="text"
-        value="95"
-      />
-      <input
-        aria-label="Message Width slider"
-        className="absolute w-full h-0.5 left-0 bottom-0"
-        id="messageMaxWidthStyle-range"
-        max="100"
-        min="1"
-        onChange={[Function]}
-        step="1"
-        style={
-          {
-            "accentColor": "rgba(145, 10, 103)",
-          }
-        }
-        type="range"
-        value="95"
-      />
+      <label
+        className="text-sm font-medium text-ink"
+        htmlFor="messageMaxWidthStyle"
+      >
+        Message Width
+      </label>
+      <div
+        className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+      >
+        <input
+          className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+          id="messageMaxWidthStyle"
+          inputMode="numeric"
+          maxLength={3}
+          onChange={[Function]}
+          type="text"
+          value="95"
+        />
+        <span
+          aria-hidden="true"
+          className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+        >
+          %
+        </span>
+      </div>
     </div>
-    <div
-      aria-hidden="true"
-      className="py-2 rounded-r-sm"
-      style={
-        {
-          "backgroundColor": "rgba(145, 10, 103, 0.1)",
-        }
-      }
-    >
-      %
-    </div>
+    <input
+      aria-label="Message Width slider"
+      className="control-range"
+      id="messageMaxWidthStyle-range"
+      max="100"
+      min="1"
+      onChange={[Function]}
+      step="1"
+      type="range"
+      value="95"
+    />
   </div>
   <div
-    className="flex justify-between items-center"
+    className="grid gap-1.5"
   >
-    <label
-      className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-      htmlFor="messagePaddingStyle"
-      style={
-        {
-          "backgroundColor": "rgba(114, 4, 85)",
-        }
-      }
-    >
-      Message Padding:
-    </label>
-     
     <div
-      className="relative flex"
+      className="flex items-center justify-between gap-2"
     >
-      <input
-        className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-        id="messagePaddingStyle"
-        inputMode="numeric"
-        maxLength={3}
-        onChange={[Function]}
-        style={
-          {
-            "backgroundColor": "rgba(114, 4, 85, 0.1)",
-          }
-        }
-        type="text"
-        value="10"
-      />
-      <input
-        aria-label="Message Padding slider"
-        className="absolute w-full h-0.5 left-0 bottom-0"
-        id="messagePaddingStyle-range"
-        max="100"
-        min="1"
-        onChange={[Function]}
-        step="1"
-        style={
-          {
-            "accentColor": "rgba(114, 4, 85)",
-          }
-        }
-        type="range"
-        value="10"
-      />
+      <label
+        className="text-sm font-medium text-ink"
+        htmlFor="messagePaddingStyle"
+      >
+        Message Padding
+      </label>
+      <div
+        className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+      >
+        <input
+          className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+          id="messagePaddingStyle"
+          inputMode="numeric"
+          maxLength={3}
+          onChange={[Function]}
+          type="text"
+          value="10"
+        />
+        <span
+          aria-hidden="true"
+          className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+        >
+          px
+        </span>
+      </div>
     </div>
-    <div
-      aria-hidden="true"
-      className="py-2 rounded-r-sm"
-      style={
-        {
-          "backgroundColor": "rgba(114, 4, 85, 0.1)",
-        }
-      }
-    >
-      px
-    </div>
+    <input
+      aria-label="Message Padding slider"
+      className="control-range"
+      id="messagePaddingStyle-range"
+      max="100"
+      min="1"
+      onChange={[Function]}
+      step="1"
+      type="range"
+      value="10"
+    />
   </div>
   <div
-    className="flex justify-between items-center"
+    className="grid gap-1.5"
   >
-    <label
-      className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-      htmlFor="messageBorderRadiusStyle"
-      style={
-        {
-          "backgroundColor": "rgba(60, 7, 83)",
-        }
-      }
-    >
-      Message Border:
-    </label>
-     
     <div
-      className="relative flex"
+      className="flex items-center justify-between gap-2"
     >
-      <input
-        className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-        id="messageBorderRadiusStyle"
-        inputMode="numeric"
-        maxLength={3}
-        onChange={[Function]}
-        style={
-          {
-            "backgroundColor": "rgba(60, 7, 83, 0.1)",
-          }
-        }
-        type="text"
-        value="5"
-      />
-      <input
-        aria-label="Message Border slider"
-        className="absolute w-full h-0.5 left-0 bottom-0"
-        id="messageBorderRadiusStyle-range"
-        max="100"
-        min="1"
-        onChange={[Function]}
-        step="1"
-        style={
-          {
-            "accentColor": "rgba(60, 7, 83)",
-          }
-        }
-        type="range"
-        value="5"
-      />
+      <label
+        className="text-sm font-medium text-ink"
+        htmlFor="messageBorderRadiusStyle"
+      >
+        Message Border
+      </label>
+      <div
+        className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+      >
+        <input
+          className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+          id="messageBorderRadiusStyle"
+          inputMode="numeric"
+          maxLength={3}
+          onChange={[Function]}
+          type="text"
+          value="5"
+        />
+        <span
+          aria-hidden="true"
+          className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+        >
+          px
+        </span>
+      </div>
     </div>
-    <div
-      aria-hidden="true"
-      className="py-2 rounded-r-sm"
-      style={
-        {
-          "backgroundColor": "rgba(60, 7, 83, 0.1)",
-        }
-      }
-    >
-      px
-    </div>
+    <input
+      aria-label="Message Border slider"
+      className="control-range"
+      id="messageBorderRadiusStyle-range"
+      max="100"
+      min="1"
+      onChange={[Function]}
+      step="1"
+      type="range"
+      value="5"
+    />
   </div>
   <div
-    className="flex justify-between items-center"
+    className="grid gap-1.5"
   >
-    <label
-      className="basis-1/2 p-2 text-white rounded-md font-medium text-center mr-2"
-      htmlFor="inputBoxMaxWidthStyle"
-      style={
-        {
-          "backgroundColor": "rgba(3, 6, 55)",
-        }
-      }
-    >
-      Input Box Width:
-    </label>
-     
     <div
-      className="relative flex"
+      className="flex items-center justify-between gap-2"
     >
-      <input
-        className="outline-none px-2 py-2 w-full text-right rounded-l-sm "
-        id="inputBoxMaxWidthStyle"
-        inputMode="numeric"
-        maxLength={3}
-        onChange={[Function]}
-        style={
-          {
-            "backgroundColor": "rgba(3, 6, 55, 0.1)",
-          }
-        }
-        type="text"
-        value="94"
-      />
-      <input
-        aria-label="Input Box Width slider"
-        className="absolute w-full h-0.5 left-0 bottom-0"
-        id="inputBoxMaxWidthStyle-range"
-        max="100"
-        min="1"
-        onChange={[Function]}
-        step="1"
-        style={
-          {
-            "accentColor": "rgba(3, 6, 55)",
-          }
-        }
-        type="range"
-        value="94"
-      />
+      <label
+        className="text-sm font-medium text-ink"
+        htmlFor="inputBoxMaxWidthStyle"
+      >
+        Input Box Width
+      </label>
+      <div
+        className="flex items-center rounded-md border border-edge bg-surface-raised overflow-hidden"
+      >
+        <input
+          className="w-12 px-2 py-1 text-sm text-right text-ink bg-transparent outline-none"
+          id="inputBoxMaxWidthStyle"
+          inputMode="numeric"
+          maxLength={3}
+          onChange={[Function]}
+          type="text"
+          value="94"
+        />
+        <span
+          aria-hidden="true"
+          className="px-2 py-1 text-xs text-ink-muted border-l border-edge select-none"
+        >
+          %
+        </span>
+      </div>
     </div>
-    <div
-      aria-hidden="true"
-      className="py-2 rounded-r-sm"
-      style={
-        {
-          "backgroundColor": "rgba(3, 6, 55, 0.1)",
-        }
-      }
-    >
-      %
-    </div>
+    <input
+      aria-label="Input Box Width slider"
+      className="control-range"
+      id="inputBoxMaxWidthStyle-range"
+      max="100"
+      min="1"
+      onChange={[Function]}
+      step="1"
+      type="range"
+      value="94"
+    />
   </div>
 </div>
 `;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,26 @@ module.exports = {
     content: ["./src/**/*.{js,jsx,ts,tsx}", "./dist/popup.html"],
     theme: {
         extend: {
+            colors: {
+                surface: {
+                    DEFAULT: "var(--surface)",
+                    raised: "var(--surface-raised)",
+                },
+                edge: "var(--border)",
+                ink: {
+                    DEFAULT: "var(--text)",
+                    muted: "var(--text-muted)",
+                },
+                accent: {
+                    DEFAULT: "var(--accent)",
+                    contrast: "var(--accent-contrast)",
+                },
+                danger: {
+                    DEFAULT: "var(--danger)",
+                    contrast: "var(--danger-contrast)",
+                },
+                success: "var(--success)",
+            },
             animation: {
                 "fade-in": "fadeIn 0.4s ease-out",
             },


### PR DESCRIPTION
- Modernize the popup UI with ChatGPT-style theme tokens.
- Replace the purple/magenta control styling with neutral light/dark surfaces, visible sliders, and a header lockup that uses the existing icon plus a theme-aware close control.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes (`npm run validate && npm run test:ci`)
-   [ ] CI is green on this pull request
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
